### PR TITLE
fix(test): stop test-windows flaking on stopwatches and file locks

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -91,13 +91,28 @@ The canonical example is [`services/api/test/gallery-describe.test.ts`](../../se
 
 CI runs the full suite on both `ubuntu-latest` (`test-linux`) and `windows-latest` (`test-windows`), and **both are blocking**. Development happens almost entirely on Linux, so `test-windows` is where portability mistakes surface — every red `test-windows` to date has been a test written against Linux semantics rather than a product bug. The job stays blocking anyway: the code it covers (self-updater, installer, archive extraction, path handling) is precisely where Windows behaves differently, and that is also where most users are.
 
-Four rules, each one a real failure that has already cost a red build:
+Six rules, each one a real failure that has already cost a red build:
 
 **Never spell a path as a literal in an assertion.** `resolveEntryPath("/tmp/x", "web/a.js")` returns `/tmp/x/web/a.js` on Linux and `D:\tmp\x\web\a.js` on Windows — both correct. Build the expectation the same way the code does, with `join()`/`resolve()`, so the pin is the *nesting* an entry maps to rather than the separator character.
 
 **Never inject a failure with POSIX mode bits.** `chmod(dir, 0o555)` is the obvious way to make a rename or an unlink fail on Linux; on Windows the read-only attribute does not block either, so the injection silently does nothing, the operation succeeds, and a test expecting `rejects.toThrow()` goes red. This failure mode is dangerous because it **fails open** — an assertion that passes under a Windows-inert injection is telling you the injection did nothing, not that the code handled the failure.
 
 **Never assert on an RSS or an mtime delta.** Windows reports the process working set, which includes file-cache pages: a correctly-streaming 128 MB download measured +302 MB there against +17 MB on Linux. NTFS likewise bumps mtime even for a read-only SQLite open. Pin the property you actually care about instead — the schema is unchanged, the digest matches, the file on disk is the right size.
+
+**Never assert that something happened within a wall-clock deadline.** The Windows runner stalls for seconds at a time, and whichever test is holding a stopwatch when that happens goes red. The stalls are indiscriminate — over two weeks they took out an asset-store delete, a dice-script resolver, a `bump-version` argument parse, a DOM expand and a SOCKS5 first-chunk deadline, all at 5–22 s for work that takes milliseconds. Widening the deadline only moves the threshold; the stopwatch is the defect. Pin the *ordering* instead, by having the fixture record what it did and asserting on that:
+
+```ts
+let secondChunkSent = false;
+// ...fixture: secondChunkSent = true, immediately before writing chunk two.
+
+const first = await iterator.next();
+expect(first.value.length).toBeGreaterThan(0);
+// The client had chunk one before the server produced chunk two — which is
+// what "streamed, not buffered" means, at any speed.
+expect(secondChunkSent).toBe(false);
+```
+
+A deadline is acceptable only as a *hang* guard, where the budget is orders of magnitude above the real cost and exceeding it means "never" rather than "slowly".
 
 **Never shell out to a tool that is not on every runner.** `zip` is not installed on `windows-latest` (`tar` is). Prefer an in-process library; if the point of the test is specifically to consume a *foreign* artifact, branch to the platform's native tool — `Compress-Archive` on Windows — rather than dropping the case.
 
@@ -112,6 +127,8 @@ afterEach(async () => {
 ```
 
 The same applies to any OS handle a test holds — file descriptors, servers, watchers. On Windows the cleanup step is where the leak surfaces, usually blamed on whichever test ran next.
+
+Closing the handles is necessary but not sufficient: a scanner or the search indexer can hold a file the test just wrote, and SQLite reports that as the same `unable to open database file`. That one is not a test bug and cannot be fixed in the test — `snapshotDatabase` retries it a few times before giving up. Product code that opens a file moments after creating it should expect the same treatment on Windows.
 
 ### Gating: use the smallest scope that stays honest
 

--- a/services/api/src/domain/update/update-db-snapshot.ts
+++ b/services/api/src/domain/update/update-db-snapshot.ts
@@ -19,7 +19,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { mkdir, stat } from "node:fs/promises";
+import { mkdir, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
 export interface SnapshotResult {
@@ -27,6 +27,66 @@ export interface SnapshotResult {
 	readonly path: string | null;
 	readonly bytes: number;
 	readonly message: string | null;
+}
+
+/** Attempts at the open + `VACUUM INTO` pair, the first one included. */
+export const SNAPSHOT_ATTEMPTS = 3;
+
+/** Pause between attempts — long enough for a scanner to let go of a
+ *  seconds-old file, short enough that a real failure still fails promptly. */
+const SNAPSHOT_RETRY_DELAY_MS = 250;
+
+/** Injection points. Both default to the real thing; they exist because the
+ *  retry cannot be provoked through the filesystem on every platform (Windows
+ *  ignores POSIX mode bits, so a chmod-based injection would silently no-op and
+ *  the test would pass without ever exercising the retry). */
+export interface SnapshotOptions {
+	/** How the source connection is opened. */
+	readonly openSource?: (path: string) => Database;
+	/** Pause between attempts, in ms. */
+	readonly retryDelayMs?: number;
+}
+
+/**
+ * Is this the failure a moment's wait might clear?
+ *
+ * SQLITE_CANTOPEN is what Windows produces when an antivirus scanner or the
+ * search indexer still holds a handle on a file that was written seconds ago —
+ * exactly the situation every pre-update snapshot is taken in. On Linux the
+ * same message means something durable, so retrying costs one extra attempt and
+ * changes no outcome.
+ */
+function isTransientOpenFailure(message: string): boolean {
+	return /unable to open database file/i.test(message);
+}
+
+/** Open the source read-only and vacuum it into `destination`, retrying while
+ *  the failure looks transient. Throws the last error once the budget is out. */
+async function vacuumWithRetry(
+	dbPath: string,
+	destination: string,
+	openSource: (path: string) => Database,
+	retryDelayMs: number,
+): Promise<void> {
+	for (let attempt = 1; ; attempt++) {
+		try {
+			const source = openSource(dbPath);
+			try {
+				source.run("VACUUM INTO ?", [destination]);
+			} finally {
+				source.close();
+			}
+			return;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			if (attempt >= SNAPSHOT_ATTEMPTS || !isTransientOpenFailure(message)) throw err;
+			// A torn attempt can leave a partial file behind, and VACUUM INTO
+			// refuses to write over one — without this the retry would fail for a
+			// completely different reason than the one being retried.
+			await rm(destination, { force: true });
+			await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+		}
+	}
 }
 
 /** Where a pre-update snapshot for `version` lives under the data dir. */
@@ -47,8 +107,11 @@ export async function snapshotDatabase(
 	dbPath: string,
 	dataDir: string,
 	version: string,
+	options: SnapshotOptions = {},
 ): Promise<SnapshotResult> {
 	const destination = snapshotPathFor(dataDir, version);
+	const openSource = options.openSource ?? ((path: string) => new Database(path, { readonly: true }));
+	const retryDelayMs = options.retryDelayMs ?? SNAPSHOT_RETRY_DELAY_MS;
 
 	try {
 		if (!(await stat(dbPath).then(() => true, () => false))) {
@@ -70,12 +133,7 @@ export async function snapshotDatabase(
 			return { ok: true, path: destination, bytes: existing.size, message: null };
 		}
 
-		const source = new Database(dbPath, { readonly: true });
-		try {
-			source.run("VACUUM INTO ?", [destination]);
-		} finally {
-			source.close();
-		}
+		await vacuumWithRetry(dbPath, destination, openSource, retryDelayMs);
 
 		const written = await stat(destination);
 		return { ok: true, path: destination, bytes: written.size, message: null };

--- a/services/api/test/socks-proxy-traversal.test.ts
+++ b/services/api/test/socks-proxy-traversal.test.ts
@@ -61,11 +61,27 @@ const SOCKS_PASS = "socks-upstream-secret";
 const TARGET_HOST = "provider.test";
 
 // ─── Delayed-stream constants ──────────────────────────────────────────────
-/** Gap between the first and second SSE chunks — proves streaming is live. */
-const STREAM_DELAY_MS = 300;
-/** Deadline for the first chunk — well under the gap so a buffered response
- *  (the known failure mode) would fail this assertion. Declared AND asserted. */
-const FIRST_CHUNK_DEADLINE_MS = 150;
+/**
+ * Gap between the first and second SSE chunks — proves streaming is live.
+ *
+ * Generous on purpose. The streaming pin below is an ORDERING check, not a
+ * latency budget, so this gap only has to outlast the scheduler stall between
+ * the client receiving chunk one and the test observing it. Windows CI runners
+ * routinely stall for seconds at a time; the previous 300 ms gap with a 150 ms
+ * first-chunk deadline turned one such stall into a red build (171 ms measured).
+ */
+const STREAM_DELAY_MS = 1_500;
+
+/**
+ * Flipped by the fixture the instant it produces the delayed second chunk.
+ *
+ * The streaming test reads it once the FIRST chunk has arrived: still `false`
+ * means the client had chunk one before the server had even written chunk two,
+ * which is exactly what "not buffered" means — and it stays true regardless of
+ * how slow the machine is. Reset per response; the tests in this file run
+ * sequentially, so a single module-level flag is unambiguous.
+ */
+let secondChunkSent = false;
 
 // ─── HTTPS target (the provider endpoint) ──────────────────────────────────
 
@@ -95,12 +111,14 @@ function targetResponse(request: Request): Response | Promise<Response> {
 function delayedStreamResponse(): Response {
 	const firstChunk = `data: ${JSON.stringify({ id: "chat_1", object: "chat.completion.chunk", created: 0, model: "test-model", choices: [{ index: 0, delta: { role: "assistant", content: "early" }, finish_reason: null }] })}\n\n`;
 	const secondChunk = `data: ${JSON.stringify({ id: "chat_1", object: "chat.completion.chunk", created: 0, model: "test-model", choices: [{ index: 0, delta: { content: "-delayed" }, finish_reason: "stop" }] })}\n\n`;
+	secondChunkSent = false;
 	return new Response(
 		new ReadableStream({
 			async start(controller) {
 				const enc = new TextEncoder();
 				controller.enqueue(enc.encode(firstChunk));
 				await new Promise((resolve) => setTimeout(resolve, STREAM_DELAY_MS));
+				secondChunkSent = true;
 				controller.enqueue(enc.encode(secondChunk));
 				controller.enqueue(enc.encode("data: [DONE]\n\n"));
 				controller.close();
@@ -421,14 +439,15 @@ describe("SOCKS5 provider proxy traversal", () => {
 		// the SAME iterator. Iterating textStream twice (break then re-iterate)
 		// would create a second iterator over an already-advanced stream.
 		const iterator = result.textStream[Symbol.asyncIterator]();
-		const start = Date.now();
 		const first = await iterator.next();
-		const elapsed = Date.now() - start;
 		expect(first.done).toBe(false);
 		expect(first.value.length).toBeGreaterThan(0);
-		// The first chunk must arrive well under the second chunk's delay — a
-		// buffered response (the known failure mode) would exceed this deadline.
-		expect(elapsed).toBeLessThan(FIRST_CHUNK_DEADLINE_MS);
+		// The first chunk reached the client before the server produced the
+		// second. A buffered response — the known failure mode — could only
+		// deliver chunk one after the whole body was written, so this flag would
+		// already be true. Ordering, not wall clock: a stalled runner cannot
+		// turn it red.
+		expect(secondChunkSent).toBe(false);
 
 		// Drain the rest through the SAME iterator so the stream completes.
 		let fullText = first.value;

--- a/services/api/test/update-preflight.test.ts
+++ b/services/api/test/update-preflight.test.ts
@@ -7,12 +7,13 @@
  */
 
 import { Database } from "bun:sqlite";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { checkFreeSpace, estimateRequiredBytes } from "../src/server/update-preflight.js";
-import { snapshotDatabase, snapshotPathFor } from "../src/domain/update/update-db-snapshot.js";
+import { SNAPSHOT_ATTEMPTS, snapshotDatabase, snapshotPathFor } from "../src/domain/update/update-db-snapshot.js";
 
 let root = "";
 
@@ -200,5 +201,91 @@ describe("snapshotDatabase", () => {
 		// baseline actually described the fixture's schema.
 		expect(before.map((r) => r.name)).toContain("chats");
 		expect(schemaOf().map((r) => r.name)).not.toContain("__drizzle_migrations");
+	});
+
+	// ── Transient SQLITE_CANTOPEN is retried ───────────────────────────────
+	//
+	// Windows hands out "unable to open database file" when an antivirus or the
+	// search indexer momentarily holds a handle on a file that was created
+	// seconds ago — which is precisely the shape of every snapshot the updater
+	// takes. The retry is driven through the `openSource` seam rather than by
+	// sabotaging the filesystem: mode bits are inert on Windows, so a real
+	// injection there would fail open and the pin would prove nothing.
+
+	/** An opener that fails the first `failures` calls, then behaves normally. */
+	function flakyOpener(failures: number, message: string, onFail?: (destination: string) => void) {
+		const state = { calls: 0 };
+		const open = (path: string): Database => {
+			state.calls++;
+			if (state.calls <= failures) {
+				onFail?.(path);
+				throw new Error(message);
+			}
+			return new Database(path, { readonly: true });
+		};
+		return { state, open };
+	}
+
+	it("retries a transient 'unable to open database file' instead of giving up", async () => {
+		const { dbPath, dataDir } = await makeWalDb(20);
+		const opener = flakyOpener(1, "unable to open database file");
+
+		const result = await snapshotDatabase(dbPath, dataDir, "4.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(opener.state.calls).toBe(2);
+		const snap = new Database(result.path ?? "", { readonly: true });
+		openDatabases.push(snap);
+		expect((snap.query("SELECT COUNT(*) AS n FROM chats").get() as { n: number }).n).toBe(20);
+	});
+
+	it("clears a partial destination between attempts — VACUUM INTO refuses to overwrite", async () => {
+		const { dbPath, dataDir } = await makeWalDb(3);
+		const destination = snapshotPathFor(dataDir, "5.0.0");
+		// A half-written snapshot is what a torn VACUUM INTO leaves behind. If the
+		// retry did not clear it, the second attempt would fail for a brand-new
+		// reason ("output file already exists") and the retry would be useless.
+		const opener = flakyOpener(1, "unable to open database file", () => {
+			mkdirSync(dirname(destination), { recursive: true });
+			writeFileSync(destination, "torn write");
+		});
+
+		const result = await snapshotDatabase(dbPath, dataDir, "5.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expect(result.ok).toBe(true);
+		expect(result.bytes).toBeGreaterThan("torn write".length);
+	});
+
+	it("gives up after the attempt budget and reports the failure", async () => {
+		const { dbPath, dataDir } = await makeWalDb(1);
+		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, "unable to open database file");
+
+		const result = await snapshotDatabase(dbPath, dataDir, "6.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expect(result.ok).toBe(false);
+		expect(opener.state.calls).toBe(SNAPSHOT_ATTEMPTS);
+		expect(result.message ?? "").toMatch(/unable to open database file/);
+	});
+
+	it("does not retry a failure that is not a transient open", async () => {
+		const { dbPath, dataDir } = await makeWalDb(1);
+		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, "disk I/O error");
+
+		const result = await snapshotDatabase(dbPath, dataDir, "7.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expect(result.ok).toBe(false);
+		expect(opener.state.calls).toBe(1);
 	});
 });


### PR DESCRIPTION
## Why

`test-windows` went red on #17 in two tests that branch never touched. Neither is a product bug — they are the two shapes the Windows runner breaks: a stopwatch, and a file another process is holding.

The runner stalls for seconds at a time, and whatever is holding a deadline when that happens loses. Over the last two weeks the same stall took out an asset-store delete (5988 ms), a dice-script resolver (5510 ms), an MAE trace pin (5347 ms), a `bump-version` argument parse (5040 ms), a DOM expand (22432 ms) and the SOCKS5 first-chunk deadline — all for work that costs milliseconds. Each was previously fixed by widening its individual timeout, which moves the threshold rather than removing the stopwatch.

## SOCKS5 streaming: ordering instead of a stopwatch

The test pinned live streaming as "first chunk arrives within 150 ms" against a 300 ms server-side gap. A stall measured 171 ms and the build went red for behaviour that was completely correct.

It now pins the ordering directly: the fixture flips a flag immediately before writing the second chunk, and the test asserts the flag is still `false` once the first chunk has arrived. That is the same property — the client had chunk one before the server produced chunk two, which is exactly what "streamed, not buffered" means — and no amount of slowness can break it.

The gap widens to 1.5 s because it no longer stands in for a latency budget; it only has to outlast the scheduler stall between the chunk arriving and the test observing it.

Verified non-vacuous: flipping the flag before the *first* chunk (simulating a buffered response) turns the assertion red.

## `snapshotDatabase`: retry a transient `SQLITE_CANTOPEN`

The snapshot failed with `unable to open database file` after 6 seconds. It had already failed identically on an unrelated branch (run 30583572777) against this same code, so it predates the quota work.

On Windows an antivirus scanner or the search indexer can hold a handle on a file that was written seconds ago — which is the situation every pre-update snapshot is taken in — and SQLite surfaces that as `SQLITE_CANTOPEN`. The open + `VACUUM INTO` pair now retries three times, 250 ms apart, and only for that message; anything else still fails on the first attempt.

Subtlety worth flagging in review: a torn attempt can leave a partial file at the destination, and `VACUUM INTO` refuses to write over an existing file. Without clearing it the retry would fail for a brand-new reason and be useless. There is a pin for exactly that.

The retry is provoked through an injected `openSource` seam rather than through the filesystem — mode bits are inert on Windows, so a `chmod`-based injection would silently no-op and the test would pass without ever exercising the retry. Four pins: success on the second attempt, partial-destination cleanup, exhausting the attempt budget, and no retry for a non-transient error.

## Docs

`docs/architecture/testing.md` gains both rules: never assert on a wall-clock deadline (with the ordering-pin recipe and the one exception — a hang guard orders of magnitude above the real cost), and a note that closing handles is necessary but not sufficient, because a scanner lock produces the same error and has to be retried in product code.

## Verification

```
bun run typecheck   clean, all 7 workspaces
bun run test        8/8 suites PASS
update-preflight + socks-proxy-traversal   36 pass, 0 fail
```
