### PR TITLE
fix(updater): retry the CANTOPEN that VACUUM INTO actually raises

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -128,7 +128,9 @@ afterEach(async () => {
 
 The same applies to any OS handle a test holds — file descriptors, servers, watchers. On Windows the cleanup step is where the leak surfaces, usually blamed on whichever test ran next.
 
-Closing the handles is necessary but not sufficient: a scanner or the search indexer can hold a file the test just wrote, and SQLite reports that as the same `unable to open database file`. That one is not a test bug and cannot be fixed in the test — `snapshotDatabase` retries it a few times before giving up. Product code that opens a file moments after creating it should expect the same treatment on Windows.
+Closing the handles is necessary but not sufficient: a scanner or the search indexer can hold a file the test just wrote, and SQLite reports that as `SQLITE_CANTOPEN`. That one is not a test bug and cannot be fixed in the test — `snapshotDatabase` retries it with a growing delay before giving up. Product code that opens a file moments after creating it should expect the same treatment on Windows.
+
+Match that condition on the error's `code`, never on its wording. `SQLITE_CANTOPEN` arrives under at least two messages — `unable to open database file` from `sqlite3_open`, and `unable to open database: <path>` from the `ATTACH` that `VACUUM INTO` performs on its *destination*. A retry predicate written against the first spelling alone silently does nothing about the second, which is how the pre-update snapshot went on failing on Windows CI after it was supposedly fixed.
 
 ### Gating: use the smallest scope that stays honest
 

--- a/services/api/src/domain/update/update-db-snapshot.ts
+++ b/services/api/src/domain/update/update-db-snapshot.ts
@@ -18,7 +18,7 @@
  * write to the database we are trying to photograph.
  */
 
-import { Database } from "bun:sqlite";
+import { Database, SQLiteError } from "bun:sqlite";
 import { mkdir, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
@@ -30,10 +30,16 @@ export interface SnapshotResult {
 }
 
 /** Attempts at the open + `VACUUM INTO` pair, the first one included. */
-export const SNAPSHOT_ATTEMPTS = 3;
+export const SNAPSHOT_ATTEMPTS = 4;
 
-/** Pause between attempts — long enough for a scanner to let go of a
- *  seconds-old file, short enough that a real failure still fails promptly. */
+/** First pause between attempts; every later one doubles it.
+ *
+ *  A flat 250 ms spent the entire retry budget inside half a second — less time
+ *  than the thing it was riding out. A scanner that has just opened a
+ *  seconds-old file does not reliably let go that fast. Backing off 250 / 500 /
+ *  1000 ms puts the last attempt ~1.75 s in, which is nothing against the cost
+ *  of aborting a user's update, while a genuinely broken snapshot still fails
+ *  in under two seconds. */
 const SNAPSHOT_RETRY_DELAY_MS = 250;
 
 /** Injection points. Both default to the real thing; they exist because the
@@ -53,11 +59,26 @@ export interface SnapshotOptions {
  * SQLITE_CANTOPEN is what Windows produces when an antivirus scanner or the
  * search indexer still holds a handle on a file that was written seconds ago —
  * exactly the situation every pre-update snapshot is taken in. On Linux the
- * same message means something durable, so retrying costs one extra attempt and
+ * same code means something durable, so retrying costs a few extra attempts and
  * changes no outcome.
+ *
+ * The code, not the wording, is the thing to test. One CANTOPEN reaches here
+ * under two different messages, because two different opens can raise it:
+ *
+ *   - `unable to open database file`   — sqlite3_open failing on the *source*.
+ *   - `unable to open database: <path>` — the ATTACH that `VACUUM INTO` performs
+ *     on its *destination*; attach.c formats that one with the filename.
+ *
+ * Matching only the first spelling is what let this through: the observed CI
+ * failure was the second one, naming `backups/pre-update-<version>.db`, so it
+ * was classified as permanent and never retried at all. The message branch
+ * remains because `SQLiteError` cannot be constructed outside bun:sqlite, so an
+ * injected opener — the seam the retry tests drive — can only ever throw a
+ * plain Error.
  */
-function isTransientOpenFailure(message: string): boolean {
-	return /unable to open database file/i.test(message);
+function isTransientOpenFailure(err: Error): boolean {
+	if (err instanceof SQLiteError) return err.code === "SQLITE_CANTOPEN";
+	return /unable to open database\b/i.test(err.message);
 }
 
 /** Open the source read-only and vacuum it into `destination`, retrying while
@@ -78,13 +99,13 @@ async function vacuumWithRetry(
 			}
 			return;
 		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			if (attempt >= SNAPSHOT_ATTEMPTS || !isTransientOpenFailure(message)) throw err;
+			const failure = err instanceof Error ? err : new Error(String(err));
+			if (attempt >= SNAPSHOT_ATTEMPTS || !isTransientOpenFailure(failure)) throw err;
 			// A torn attempt can leave a partial file behind, and VACUUM INTO
 			// refuses to write over one — without this the retry would fail for a
 			// completely different reason than the one being retried.
 			await rm(destination, { force: true });
-			await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+			await new Promise((resolve) => setTimeout(resolve, retryDelayMs * 2 ** (attempt - 1)));
 		}
 	}
 }

--- a/services/api/test/update-preflight.test.ts
+++ b/services/api/test/update-preflight.test.ts
@@ -6,14 +6,19 @@
  * install without a readable copy of the database from before it.
  */
 
-import { Database } from "bun:sqlite";
+import { Database, SQLiteError } from "bun:sqlite";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { checkFreeSpace, estimateRequiredBytes } from "../src/server/update-preflight.js";
-import { SNAPSHOT_ATTEMPTS, snapshotDatabase, snapshotPathFor } from "../src/domain/update/update-db-snapshot.js";
+import {
+	SNAPSHOT_ATTEMPTS,
+	type SnapshotResult,
+	snapshotDatabase,
+	snapshotPathFor,
+} from "../src/domain/update/update-db-snapshot.js";
 
 let root = "";
 
@@ -88,6 +93,21 @@ describe("checkFreeSpace", () => {
 });
 
 describe("snapshotDatabase", () => {
+	/**
+	 * Assert a snapshot succeeded, in a way that says why when it did not.
+	 *
+	 * `snapshotDatabase` never throws: a failure is `ok: false` plus a message,
+	 * and the message is the only place the reason exists. Asserting on `ok`
+	 * alone reduces every failure to "Expected: true, Received: false" — which
+	 * is exactly what a Windows-only CI flake here produced, throwing away the
+	 * one sentence that identified it. Assert the message first so a red run
+	 * carries the diagnosis.
+	 */
+	function expectSnapshotOk(result: SnapshotResult): void {
+		expect(result.message).toBeNull();
+		expect(result.ok).toBe(true);
+	}
+
 	async function makeWalDb(rows: number): Promise<{ dbPath: string; dataDir: string; db: Database }> {
 		const dataDir = join(root, "data");
 		await mkdir(dataDir, { recursive: true });
@@ -108,7 +128,7 @@ describe("snapshotDatabase", () => {
 
 		const result = await snapshotDatabase(dbPath, dataDir, "1.2.3");
 
-		expect(result.ok).toBe(true);
+		expectSnapshotOk(result);
 		expect(result.path).toBe(snapshotPathFor(dataDir, "1.2.3"));
 		expect(result.bytes).toBeGreaterThan(0);
 
@@ -138,7 +158,7 @@ describe("snapshotDatabase", () => {
 		const { dbPath, dataDir } = await makeWalDb(1);
 		const result = await snapshotDatabase(dbPath, dataDir, "../../escaped");
 
-		expect(result.ok).toBe(true);
+		expectSnapshotOk(result);
 		// The real property: the file lands directly in backups/, whatever the
 		// separators got mangled into. (Dots survive sanitization — only the
 		// path separators are replaced — so a substring check for ".." would
@@ -151,8 +171,8 @@ describe("snapshotDatabase", () => {
 		const { dbPath, dataDir } = await makeWalDb(10);
 		const first = await snapshotDatabase(dbPath, dataDir, "2.0.0");
 		const second = await snapshotDatabase(dbPath, dataDir, "2.0.0");
-		expect(first.ok).toBe(true);
-		expect(second.ok).toBe(true);
+		expectSnapshotOk(first);
+		expectSnapshotOk(second);
 		expect(second.path).toBe(first.path);
 	});
 
@@ -213,29 +233,47 @@ describe("snapshotDatabase", () => {
 	// injection there would fail open and the pin would prove nothing.
 
 	/** An opener that fails the first `failures` calls, then behaves normally. */
-	function flakyOpener(failures: number, message: string, onFail?: (destination: string) => void) {
+	function flakyOpener(failures: number, failure: Error, onFail?: (destination: string) => void) {
 		const state = { calls: 0 };
 		const open = (path: string): Database => {
 			state.calls++;
 			if (state.calls <= failures) {
 				onFail?.(path);
-				throw new Error(message);
+				throw failure;
 			}
 			return new Database(path, { readonly: true });
 		};
 		return { state, open };
 	}
 
+	/**
+	 * The SQLITE_CANTOPEN object bun:sqlite actually throws.
+	 *
+	 * It cannot be fabricated — `new SQLiteError(...)` throws "SQLiteError can
+	 * only be constructed by bun:sqlite" — so it has to be provoked, and opening
+	 * a database under a directory that does not exist provokes it on every
+	 * platform. Retrying is keyed on `code`, and only a real error object has one.
+	 */
+	function realCantOpenError(): SQLiteError {
+		try {
+			new Database(join(root, "no-such-directory", "x.db"), { readonly: true });
+		} catch (err) {
+			if (err instanceof SQLiteError) return err;
+			throw err;
+		}
+		throw new Error("opening a database under a missing directory was expected to fail");
+	}
+
 	it("retries a transient 'unable to open database file' instead of giving up", async () => {
 		const { dbPath, dataDir } = await makeWalDb(20);
-		const opener = flakyOpener(1, "unable to open database file");
+		const opener = flakyOpener(1, new Error("unable to open database file"));
 
 		const result = await snapshotDatabase(dbPath, dataDir, "4.0.0", {
 			openSource: opener.open,
 			retryDelayMs: 0,
 		});
 
-		expect(result.ok).toBe(true);
+		expectSnapshotOk(result);
 		expect(opener.state.calls).toBe(2);
 		const snap = new Database(result.path ?? "", { readonly: true });
 		openDatabases.push(snap);
@@ -248,7 +286,7 @@ describe("snapshotDatabase", () => {
 		// A half-written snapshot is what a torn VACUUM INTO leaves behind. If the
 		// retry did not clear it, the second attempt would fail for a brand-new
 		// reason ("output file already exists") and the retry would be useless.
-		const opener = flakyOpener(1, "unable to open database file", () => {
+		const opener = flakyOpener(1, new Error("unable to open database file"), () => {
 			mkdirSync(dirname(destination), { recursive: true });
 			writeFileSync(destination, "torn write");
 		});
@@ -258,13 +296,13 @@ describe("snapshotDatabase", () => {
 			retryDelayMs: 0,
 		});
 
-		expect(result.ok).toBe(true);
+		expectSnapshotOk(result);
 		expect(result.bytes).toBeGreaterThan("torn write".length);
 	});
 
 	it("gives up after the attempt budget and reports the failure", async () => {
 		const { dbPath, dataDir } = await makeWalDb(1);
-		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, "unable to open database file");
+		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, new Error("unable to open database file"));
 
 		const result = await snapshotDatabase(dbPath, dataDir, "6.0.0", {
 			openSource: opener.open,
@@ -278,7 +316,7 @@ describe("snapshotDatabase", () => {
 
 	it("does not retry a failure that is not a transient open", async () => {
 		const { dbPath, dataDir } = await makeWalDb(1);
-		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, "disk I/O error");
+		const opener = flakyOpener(Number.MAX_SAFE_INTEGER, new Error("disk I/O error"));
 
 		const result = await snapshotDatabase(dbPath, dataDir, "7.0.0", {
 			openSource: opener.open,
@@ -287,5 +325,65 @@ describe("snapshotDatabase", () => {
 
 		expect(result.ok).toBe(false);
 		expect(opener.state.calls).toBe(1);
+	});
+
+	it("retries the destination spelling of CANTOPEN — 'unable to open database: <path>'", async () => {
+		// The regression this pins. SQLITE_CANTOPEN reaches the retry under two
+		// messages: sqlite3_open on the source says "unable to open database
+		// file", and the ATTACH that VACUUM INTO runs on its destination says
+		// "unable to open database: <path>". Only the first was matched, so the
+		// second — the one Windows CI actually produced, naming
+		// backups/pre-update-1.2.3.db — was treated as permanent and the whole
+		// retry sat idle.
+		const { dbPath, dataDir } = await makeWalDb(20);
+		const destination = snapshotPathFor(dataDir, "8.0.0");
+		const opener = flakyOpener(1, new Error(`unable to open database: ${destination}`));
+
+		const result = await snapshotDatabase(dbPath, dataDir, "8.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expectSnapshotOk(result);
+		expect(opener.state.calls).toBe(2);
+	});
+
+	it("retries on the error object bun:sqlite really throws, not just its wording", async () => {
+		// Production never sees a hand-written Error — it sees a SQLiteError, and
+		// its `code` is the same SQLITE_CANTOPEN under either message. Keying on
+		// the code is what stops the next reword of SQLite's error strings from
+		// silently disabling this retry again.
+		const { dbPath, dataDir } = await makeWalDb(5);
+		const cantOpen = realCantOpenError();
+		expect(cantOpen.code).toBe("SQLITE_CANTOPEN");
+		const opener = flakyOpener(1, cantOpen);
+
+		const result = await snapshotDatabase(dbPath, dataDir, "9.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 0,
+		});
+
+		expectSnapshotOk(result);
+		expect(opener.state.calls).toBe(2);
+	});
+
+	it("waits longer after each failed attempt instead of a flat delay", async () => {
+		// Two failures means two waits. Flat would spend 40 + 40; backing off
+		// spends 40 + 80. Asserted as a lower bound only: a loaded CI box makes
+		// timers overshoot, never undershoot, so this cannot flake the way an
+		// upper bound would.
+		const { dbPath, dataDir } = await makeWalDb(1);
+		const opener = flakyOpener(2, new Error("unable to open database file"));
+
+		const started = performance.now();
+		const result = await snapshotDatabase(dbPath, dataDir, "10.0.0", {
+			openSource: opener.open,
+			retryDelayMs: 40,
+		});
+		const elapsed = performance.now() - started;
+
+		expectSnapshotOk(result);
+		expect(opener.state.calls).toBe(3);
+		expect(elapsed).toBeGreaterThanOrEqual(110);
 	});
 });


### PR DESCRIPTION
## The failure

`snapshotDatabase > produces a snapshot that opens and holds the same rows, WAL included` fails intermittently on `test-windows`. It went red on [run 31263188185](https://github.com/Noineri/vibe_tavern/actions/runs/31263188185) (PR #20) and passed on a re-run of the same commit.

Attempt 1's log (job 93117058266) still had the `console.error` the test threw away:

```
[update] pre-update database snapshot failed: unable to open database:
  C:\...\vt-preflight-9sQKBj\data\backups\pre-update-1.2.3.db
```

That names the **destination**, not the source.

## Root cause

The retry added in #19 matched `/unable to open database file/i` — what `sqlite3_open` says about the *source*. The failure Windows actually produces comes from the `ATTACH` that `VACUUM INTO` performs on its *destination*, and `attach.c` formats that one with the filename:

| failure | message | code |
|---|---|---|
| `sqlite3_open` on the source | `unable to open database file` | `SQLITE_CANTOPEN` |
| `VACUUM INTO` on the destination | `unable to open database: <path>` | `SQLITE_CANTOPEN` |

So the second spelling was classified as permanent, threw on attempt 1, and **the retry never ran once**. The ~6 s in the log is the fixture's 500 unbatched inserts on a Windows runner, not retry time — the whole budget was 500 ms.

## Fix

- Key the predicate on the error's `code`, identical under either wording. The message branch stays only because `SQLiteError` cannot be constructed outside `bun:sqlite`, so the injected opener the retry tests drive can never throw anything else.
- Back the delay off 250/500/1000 ms over four attempts. A flat 250 ms twice spent the entire budget inside half a second — less than the scanner hold it was meant to outlast. Worst case is now ~1.75 s, against the cost of aborting someone's update.
- `expectSnapshotOk` asserts `result.message` before `ok`, so the next red run says *why* instead of `Received: false`.
- `docs/architecture/testing.md` stated the failure surfaces as "the same `unable to open database file`" — that exact string is what the predicate was written against, so it's corrected.

The assertion is unchanged and nothing is skipped on Windows; the behaviour it pins is the Windows-specific one.

## Not just CI

`snapshotDatabase` takes the pre-update backup for real users, and `update-orchestrator` aborts the update when it returns not-ok. A Windows user could be told their update failed because something held a file for a quarter second.

## Verification

Reverted the predicate and delay to their old form and re-ran: both new pins fail (`retries the destination spelling of CANTOPEN`, and 81 ms elapsed vs the required ≥ 110), and the output now prints the reason. Restored, then from `vibe_tavern/`:

- `bun run typecheck` — 7/7 packages clean, type-gate 0 violations
- `bun run test` — 8/8 suites pass

## Note

Zero file overlap with #20 — this targets `dev` because the bug is on `dev` and exposes every branch, not just the npm work.

One thing deliberately left out: the same red run also hit `EBUSY: resource busy or locked, rm` in the `afterEach` cleanup (`update-preflight.test.ts:39`), counted as a separate error. This fix likely removes its usual trigger, but `force: true` does not help with EBUSY and it needs its own decision about retrying cleanup without letting a genuinely undeletable dir pass silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)