### PR TITLE
perf(ci): 5m24s -> 2m58s, most of it Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
       # is a local admin, so the preference applies without Tamper Protection
       # getting in the way. Throwaway VM, destroyed at the end of the job.
       - name: Disable Defender real-time scanning
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected | Format-List
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
@@ -138,7 +140,9 @@ jobs:
       - uses: actions/checkout@v5
       # See test-windows: `bun install` alone costs 74s here against 3.7s on Linux.
       - name: Disable Defender real-time scanning
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected | Format-List
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # `bun install` writes 26.5k files / 764 MB, and Defender scans every one:
-      # the same install costs 3.7s on Linux and 55-92s here. The runner account
-      # is a local admin, so the preference applies without Tamper Protection
-      # getting in the way. Throwaway VM, destroyed at the end of the job.
+      # the same install costs 3.7s on Linux and 43-101s here. Throwaway VM,
+      # destroyed at the end of the job.
+      #
+      # The status line is not decoration. This runner image reports
+      # IsTamperProtected=False and the preference does apply, but the effect on
+      # install is inside the noise: 43-101s across 10 runs without it against
+      # 44-61s across 4 with it. Anyone re-measuring needs to know the lever was
+      # actually pulled before blaming the numbers on it — and if a future image
+      # turns Tamper Protection on, `Set-MpPreference` will keep exiting 0 while
+      # silently doing nothing, and only this line will say so.
       - name: Disable Defender real-time scanning
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true
@@ -138,7 +145,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      # See test-windows: `bun install` alone costs 74s here against 3.7s on Linux.
+      # See test-windows for what the status line is for.
       - name: Disable Defender real-time scanning
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,21 +84,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      # `bun install` writes 26.5k files / 764 MB, and Defender scans every one:
-      # the same install costs 3.7s on Linux and 43-101s here. Throwaway VM,
-      # destroyed at the end of the job.
-      #
-      # The status line is not decoration. This runner image reports
-      # IsTamperProtected=False and the preference does apply, but the effect on
-      # install is inside the noise: 43-101s across 10 runs without it against
-      # 44-61s across 4 with it. Anyone re-measuring needs to know the lever was
-      # actually pulled before blaming the numbers on it — and if a future image
-      # turns Tamper Protection on, `Set-MpPreference` will keep exiting 0 while
-      # silently doing nothing, and only this line will say so.
-      - name: Disable Defender real-time scanning
-        run: |
-          Set-MpPreference -DisableRealtimeMonitoring $true
-          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected | Format-List
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
@@ -145,18 +130,18 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
-      # See test-windows for what the status line is for.
-      - name: Disable Defender real-time scanning
-        run: |
-          Set-MpPreference -DisableRealtimeMonitoring $true
-          Get-MpComputerStatus | Select-Object RealTimeProtectionEnabled, IsTamperProtected | Format-List
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
       - run: bun install --frozen-lockfile
       - name: Install Inno Setup
         run: choco install innosetup --no-progress --yes
-      - run: bun scripts/build-installer.ts
+      # --fast-compression: this installer is never uploaded (see the note at the
+      # top of the file), so the compile is the whole point and lzma2/ultra64
+      # over a solid block was spending ~95s of a ~108s step on a ~100 MB binary
+      # that gets deleted with the runner. release.yml builds the shipped one at
+      # full compression. Never add this flag there.
+      - run: bun scripts/build-installer.ts --fast-compression
         env:
           ISCC_PATH: "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe"
       - run: bun scripts/build-windows-dist.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,13 @@ concurrency:
 # ever cut. This replaces the old separate dry-run.yml (deleted).
 #
 # Gating model:
-#   - typecheck, test-linux, and test-windows are all blocking. The full
-#     `bun run test` suite runs on both platforms because the repo ships a
-#     Windows installer and the filesystem/Glob semantics are platform-sensitive.
+#   - typecheck, test-linux, and test-windows are all blocking. Linux runs the
+#     full `bun run test` suite; Windows runs everything with platform-sensitive
+#     behaviour to pin, because the repo ships a Windows installer and the
+#     filesystem/Glob semantics differ there. What Windows skips, and why, is
+#     declared in scripts/test.ts (`skipOnWindows`) and in the two
+#     `skipIf(process.platform === "win32")` gates in scripts/*.test.ts —
+#     not here, so a dev running `bun run test` locally sees the same thing CI does.
 #   - The 4 platform builds fan out after typecheck passes.
 # Nothing is published; the docker job only loads locally to prove the image builds.
 # Build artifacts are intentionally NOT uploaded — CI verifies compilation only,
@@ -80,6 +84,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+      # `bun install` writes 26.5k files / 764 MB, and Defender scans every one:
+      # the same install costs 3.7s on Linux and 55-92s here. The runner account
+      # is a local admin, so the preference applies without Tamper Protection
+      # getting in the way. Throwaway VM, destroyed at the end of the job.
+      - name: Disable Defender real-time scanning
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"
@@ -126,6 +136,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v5
+      # See test-windows: `bun install` alone costs 74s here against 3.7s on Linux.
+      - name: Disable Defender real-time scanning
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.14"

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -89,7 +89,19 @@ The canonical example is [`services/api/test/gallery-describe.test.ts`](../../se
 
 ## Cross-platform: the suite runs on Windows too
 
-CI runs the full suite on both `ubuntu-latest` (`test-linux`) and `windows-latest` (`test-windows`), and **both are blocking**. Development happens almost entirely on Linux, so `test-windows` is where portability mistakes surface — every red `test-windows` to date has been a test written against Linux semantics rather than a product bug. The job stays blocking anyway: the code it covers (self-updater, installer, archive extraction, path handling) is precisely where Windows behaves differently, and that is also where most users are.
+CI runs on both `ubuntu-latest` (`test-linux`) and `windows-latest` (`test-windows`), and **both are blocking**. Development happens almost entirely on Linux, so `test-windows` is where portability mistakes surface — every red `test-windows` to date has been a test written against Linux semantics rather than a product bug. The job stays blocking anyway: the code it covers (self-updater, installer, archive extraction, path handling) is precisely where Windows behaves differently, and that is also where most users are.
+
+Linux runs everything. Windows runs everything with platform-sensitive behaviour to pin, which is not the same list — a Windows runner costs 2–4× per syscall (process creation and file creation above all), so coverage that is identical on both platforms is paid for once, on Linux. What Windows skips is declared in the test code, never in the workflow, so a `bun run test` on a Windows dev box behaves like CI:
+
+| Skipped on Windows | Declared at | Why |
+|---|---|---|
+| the whole `web` suite | `skipOnWindows` in [`scripts/test.ts`](../../scripts/test.ts) | 160 of its 162 files are React components and stores; two touch `node:fs`/`node:path`/`process.platform`. ~83s for no platform coverage. `bun run test web` still runs it there. |
+| `scripts/cli-args.test.ts` | `test.skipIf(process.platform === "win32")` | Nine cases that each spawn a full `bun` to pin argv parsing — pure Bun/Node semantics. |
+| `scripts/bump-version.test.ts` | `describe.skipIf(process.platform === "win32")` | Builds a disposable workspace and two git repos per case; the release script it covers only ever runs on the Linux release job. |
+
+Adding to that list is a judgement call with one rule: **do not leave a test green on Windows when its named behaviour is not being exercised there.** Skip the whole thing and say why, or keep it running on both. A test that silently no-ops is worse than a skip.
+
+Suites run several at a time (`suiteConcurrency()` in [`scripts/test.ts`](../../scripts/test.ts): half the cores, floored at 2, capped at 4), so any suite may be competing with `web`'s own 8-way subprocess pool for the box. That is why every `bun test` invocation carries `--timeout 15000` on every platform — bun's 5s default is a product-sized budget, and a test doing a normal amount of SQLite + filesystem work can lose seconds to contention alone. **Do not treat that headroom as a licence for slow tests**; it is a floor for a loaded runner, not a budget.
 
 Six rules, each one a real failure that has already cost a red build:
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -99,6 +99,8 @@ Linux runs everything. Windows runs everything with platform-sensitive behaviour
 | `scripts/cli-args.test.ts` | `test.skipIf(process.platform === "win32")` | Nine cases that each spawn a full `bun` to pin argv parsing — pure Bun/Node semantics. |
 | `scripts/bump-version.test.ts` | `describe.skipIf(process.platform === "win32")` | Builds a disposable workspace and two git repos per case; the release script it covers only ever runs on the Linux release job. |
 
+**Never conclude anything from a single Windows CI run.** Two runs of identical test code on this branch, minutes apart, reported `api` at 115.5s and 68.5s and `db` at 103.4s and 62.7s — the slow one drew an `eastus` runner, the fast one `northcentralus`. The `bun install` step ranges 43–101s across runs with no code change at all. Any Windows timing claim needs several samples and a stated range, or it is measuring which machine GitHub happened to hand out.
+
 Adding to that list is a judgement call with one rule: **do not leave a test green on Windows when its named behaviour is not being exercised there.** Skip the whole thing and say why, or keep it running on both. A test that silently no-ops is worse than a skip.
 
 Suites run several at a time (`suiteConcurrency()` in [`scripts/test.ts`](../../scripts/test.ts): half the cores, floored at 2, capped at 4), so any suite may be competing with `web`'s own 8-way subprocess pool for the box. That is why every `bun test` invocation carries `--timeout 15000` on every platform — bun's 5s default is a product-sized budget, and a test doing a normal amount of SQLite + filesystem work can lose seconds to contention alone. **Do not treat that headroom as a licence for slow tests**; it is a floor for a loaded runner, not a budget.

--- a/installer/vibe-tavern.iss
+++ b/installer/vibe-tavern.iss
@@ -27,6 +27,17 @@
 #define AppExeName "vibe-tavern.exe"
 #define AppURL "https://github.com/Noineri/vibe_tavern"
 
+; Compression defaults to what ships. CI overrides it (see build-installer.ts
+; --fast-compression): there the installer is thrown away and only has to prove
+; it compiles, and lzma2/ultra64 over a solid block spends ~95s of a ~108s step
+; squeezing a ~100 MB binary nobody downloads. Never override this for a release.
+#if !Defined(Compression)
+  #define Compression "lzma2/ultra64"
+#endif
+#if !Defined(SolidCompression)
+  #define SolidCompression "yes"
+#endif
+
 [Setup]
 AppId={{B7E8F1A2-3D4C-5E6F-8A9B-0C1D2E3F4A5B}
 AppName={#AppName}
@@ -39,8 +50,8 @@ AllowNoIcons=yes
 OutputDir={#ProjectRoot}\out\installer
 OutputBaseFilename=vibe-tavern-setup
 SetupIconFile={#ProjectRoot}\apps\web\public\logo.ico
-Compression=lzma2/ultra64
-SolidCompression=yes
+Compression={#Compression}
+SolidCompression={#SolidCompression}
 WizardStyle=modern
 PrivilegesRequired=admin
 ArchitecturesAllowed=x64compatible

--- a/scripts/build-installer.test.ts
+++ b/scripts/build-installer.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test";
+import { FAST_COMPRESSION_FLAG, isccArgs } from "./build-installer.js";
+
+const ISCC = "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe";
+const ROOT = "D:\\a\\vibe_tavern\\vibe_tavern";
+const ISS = "D:\\a\\vibe_tavern\\vibe_tavern\\installer\\vibe-tavern.iss";
+
+test("ships the installer at the compression declared in the .iss", () => {
+	// The release artifact is what users download; nothing on the command line
+	// may weaken it, so a default build passes no compression override at all
+	// and the .iss `#if !Defined` fallbacks (lzma2/ultra64, solid) apply.
+	const args = isccArgs(ISCC, ROOT, "1.1.2", ISS, false);
+
+	expect(args).toEqual([ISCC, `/DProjectRoot=${ROOT}`, "/DAppVersion=1.1.2", ISS]);
+	expect(args.join(" ")).not.toContain("Compression");
+});
+
+test("drops compression entirely only when asked", () => {
+	// CI throws the installer away and only needs to know it compiles; ultra64
+	// over a solid block costs ~95s of a ~108s step for an artifact nobody
+	// downloads. The script still parses, every [Files] entry still resolves.
+	const args = isccArgs(ISCC, ROOT, "1.1.2", ISS, true);
+
+	expect(args).toEqual([
+		ISCC,
+		`/DProjectRoot=${ROOT}`,
+		"/DAppVersion=1.1.2",
+		"/DCompression=none",
+		"/DSolidCompression=no",
+		ISS,
+	]);
+});
+
+test("keeps every /D value a bare identifier", () => {
+	// ISPP evaluates /D values as expressions, so `lzma2/fast` is a division and
+	// `lzma2/ultra64` would be too. Only the .iss may spell a slashed level; the
+	// command line must not, or ISCC fails on a line nobody edited.
+	const overrides = isccArgs(ISCC, ROOT, "1.1.2", ISS, true).filter((arg) => arg.startsWith("/DCompression") || arg.startsWith("/DSolidCompression"));
+
+	expect(overrides.length).toBe(2);
+	for (const override of overrides) {
+		expect(override.split("=")[1]).toMatch(/^[A-Za-z0-9_]+$/);
+	}
+});
+
+test("keeps the script path last so ISCC reads every /D that precedes it", () => {
+	// ISCC takes the script as its trailing positional; a /D after it is not a
+	// define, it is a second script name.
+	for (const fast of [false, true]) {
+		expect(isccArgs(ISCC, ROOT, "1.1.2", ISS, fast).at(-1)).toBe(ISS);
+	}
+});
+
+test("names the flag the workflow actually passes", () => {
+	// ci.yml spells this literally; a rename here without one there silently
+	// restores the slow path instead of failing.
+	expect(FAST_COMPRESSION_FLAG).toBe("--fast-compression");
+});

--- a/scripts/build-installer.ts
+++ b/scripts/build-installer.ts
@@ -6,7 +6,7 @@
  *   2. Invoke ISCC (Inno Setup Compiler) to produce the installer
  *
  * Usage:
- *   bun scripts/build-installer.ts
+ *   bun scripts/build-installer.ts [--fast-compression]
  *
  * Prerequisites:
  *   - Bun runtime
@@ -19,6 +19,8 @@
 
 import { join, resolve } from "node:path";
 import { VERSION } from "./_version.js";
+
+export const FAST_COMPRESSION_FLAG = "--fast-compression";
 
 const ROOT = resolve(import.meta.dir, "..");
 const STANDALONE_OUT = join(ROOT, "out", "standalone");
@@ -52,6 +54,34 @@ async function findIscc(): Promise<string> {
 	}
 
 	return "ISCC";
+}
+
+/**
+ * ISCC command line. `fastCompression` is for callers that only need to know the
+ * installer compiles — CI throws the artifact away, and lzma2/ultra64 over a
+ * solid block costs ~95s of a ~108s step there. The compile still verifies what
+ * it always did: the script parses, every [Files] entry resolves, [Code]
+ * compiles. What it stops exercising is the LZMA pass itself, which release.yml
+ * runs on every tag. Release builds must never pass it.
+ *
+ * `none` rather than a level like `lzma2/fast` on purpose: ISPP evaluates `/D`
+ * values as expressions, so a `/` in the value is a division operator waiting to
+ * happen. Every value here must stay a bare identifier.
+ */
+export function isccArgs(
+	isccPath: string,
+	root: string,
+	version: string,
+	issFile: string,
+	fastCompression: boolean,
+): readonly string[] {
+	return [
+		isccPath,
+		`/DProjectRoot=${root}`,
+		`/DAppVersion=${version}`,
+		...(fastCompression ? ["/DCompression=none", "/DSolidCompression=no"] : []),
+		issFile,
+	];
 }
 
 async function main() {
@@ -89,11 +119,16 @@ async function main() {
 
 	console.log(`   Version: ${VERSION}`);
 
+	const fastCompression = process.argv.slice(2).includes(FAST_COMPRESSION_FLAG);
+	if (fastCompression) {
+		console.log("   Compression: lzma2/fast, non-solid (verification build — do not ship)");
+	}
+
 	const isccPath = await findIscc();
 	console.log(`   ISCC: ${isccPath}`);
 
 	const isccProc = Bun.spawn(
-		[isccPath, `/DProjectRoot=${ROOT}`, `/DAppVersion=${VERSION}`, ISS_FILE],
+		[...isccArgs(isccPath, ROOT, VERSION, ISS_FILE, fastCompression)],
 		{ cwd: ROOT, stdout: "inherit", stderr: "inherit", stdin: "inherit" },
 	);
 
@@ -115,4 +150,7 @@ async function main() {
 	console.log(`   ${EXPECTED_SETUP}`);
 }
 
-main();
+// Guarded so `isccArgs` can be imported without running an installer build.
+if (import.meta.main) {
+	await main();
+}

--- a/scripts/build-installer.ts
+++ b/scripts/build-installer.ts
@@ -120,17 +120,18 @@ async function main() {
 	console.log(`   Version: ${VERSION}`);
 
 	const fastCompression = process.argv.slice(2).includes(FAST_COMPRESSION_FLAG);
-	if (fastCompression) {
-		console.log("   Compression: lzma2/fast, non-solid (verification build — do not ship)");
-	}
-
 	const isccPath = await findIscc();
 	console.log(`   ISCC: ${isccPath}`);
 
-	const isccProc = Bun.spawn(
-		[...isccArgs(isccPath, ROOT, VERSION, ISS_FILE, fastCompression)],
-		{ cwd: ROOT, stdout: "inherit", stderr: "inherit", stdin: "inherit" },
-	);
+	const args = isccArgs(isccPath, ROOT, VERSION, ISS_FILE, fastCompression);
+	// Echoed from the args rather than restated, so the line cannot claim one
+	// compression while ISCC is handed another.
+	const overrides = args.filter((arg) => arg.startsWith("/DCompression=") || arg.startsWith("/DSolidCompression="));
+	if (overrides.length > 0) {
+		console.log(`   Verification build — do not ship: ${overrides.join(" ")}`);
+	}
+
+	const isccProc = Bun.spawn([...args], { cwd: ROOT, stdout: "inherit", stderr: "inherit", stdin: "inherit" });
 
 	const isccExit = await isccProc.exited;
 	if (isccExit !== 0) {

--- a/scripts/bump-version.test.ts
+++ b/scripts/bump-version.test.ts
@@ -149,7 +149,14 @@ function expectSuccess(result: CommandResult): void {
 	}
 }
 
-describe("bump-version release preconditions", () => {
+/**
+ * Skipped on Windows. Every case installs a disposable workspace, creates two
+ * git repositories and shells out to `git` and `bun` — process creation is the
+ * most expensive syscall there, and the release script it covers only ever runs
+ * on the Linux release job. Together with cli-args.test.ts this is most of why
+ * the `scripts` suite costs 28.8s on Windows against 6.7s on Linux.
+ */
+describe.skipIf(process.platform === "win32")("bump-version release preconditions", () => {
 	test("rejects release branches before changing files", async () => {
 		// Given
 		const fixture = await createFixture();

--- a/scripts/cli-args.test.ts
+++ b/scripts/cli-args.test.ts
@@ -61,7 +61,17 @@ function createRepairDb(dbPath: string): void {
 	db.close();
 }
 
-test("build defaults to api-stack and treats every first argument as its target", async () => {
+/**
+ * Every case here spawns a full `bun` subprocess to pin argv parsing — pure
+ * Bun/Node semantics with nothing platform-specific to verify. Process creation
+ * is the single most expensive syscall on a Windows runner, and this file plus
+ * bump-version.test.ts are most of why the `scripts` suite costs 28.8s there
+ * against 6.7s on Linux. Skipped on Windows deliberately: the coverage is
+ * identical on both, so only Linux pays for it.
+ */
+const cliTest = test.skipIf(process.platform === "win32");
+
+cliTest("build defaults to api-stack and treats every first argument as its target", async () => {
 	// Given
 	const fixture = await copyScript("scripts/build.ts");
 
@@ -81,7 +91,7 @@ test("build defaults to api-stack and treats every first argument as its target"
 	expect(unknownResult.stderr).toContain("Unknown target: --not-a-target");
 });
 
-test("db-verify requires its positional mode and operands, while ignoring surplus operands", async () => {
+cliTest("db-verify requires its positional mode and operands, while ignoring surplus operands", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-db-verify-");
 	const dbPath = join(root, "fixture.db");
@@ -106,7 +116,7 @@ test("db-verify requires its positional mode and operands, while ignoring surplu
 	expect(dumpResult.stderr).toContain("snapshotted 1 tables, 1 rows");
 });
 
-test("type-gate enforces by default and rejects unknown arguments with exit 2", async () => {
+cliTest("type-gate enforces by default and rejects unknown arguments with exit 2", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-type-gate-");
 
@@ -126,7 +136,7 @@ test("type-gate enforces by default and rejects unknown arguments with exit 2", 
 	expect(separatedUnknownResult.stderr).toContain("unknown argument(s): --not-a-real-flag");
 });
 
-test("generate-embedded-web-manifest defaults to generation and silently ignores unknown options", async () => {
+cliTest("generate-embedded-web-manifest defaults to generation and silently ignores unknown options", async () => {
 	// Given
 	const fixture = await copyScript("scripts/generate-embedded-web-manifest.ts");
 	await mkdir(join(fixture.root, "out", "apps", "web", "assets"), { recursive: true });
@@ -149,7 +159,7 @@ test("generate-embedded-web-manifest defaults to generation and silently ignores
 	expect(await Bun.file(manifest).text()).toContain("embeddedWebFiles: Record<string, string> = {}");
 });
 
-test("migrate-to-readable-folders uses temp-CWD default data and ignores unknown flags", async () => {
+cliTest("migrate-to-readable-folders uses temp-CWD default data and ignores unknown flags", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-readable-folders-");
 	const customDb = join(root, "custom.db");
@@ -170,7 +180,7 @@ test("migrate-to-readable-folders uses temp-CWD default data and ignores unknown
 	expect(dryRunResult.stdout).toContain("Archive: disabled");
 });
 
-test("migrate-cards-to-vtf defaults to the CWD data database and ignores unknown flags", async () => {
+cliTest("migrate-cards-to-vtf defaults to the CWD data database and ignores unknown flags", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-vtf-");
 	const customDb = join(root, "custom.db");
@@ -190,7 +200,7 @@ test("migrate-cards-to-vtf defaults to the CWD data database and ignores unknown
 	expect(dryRunResult.stdout).toContain(`DB:      ${resolve(customDb)}`);
 });
 
-test("repair-thinking-tags uses argv[2] directly, including option-looking paths", async () => {
+cliTest("repair-thinking-tags uses argv[2] directly, including option-looking paths", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-repair-");
 	const defaultDb = join(root, "data", "vibe-tavern.db");
@@ -210,7 +220,7 @@ test("repair-thinking-tags uses argv[2] directly, including option-looking paths
 	expect(await Bun.file(join(root, "--not-an-option")).exists()).toBe(true);
 });
 
-test("serve-static captures default and positional port values without binding a port", async () => {
+cliTest("serve-static captures default and positional port values without binding a port", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-serve-static-");
 	const wrapper = join(root, "capture-serve.ts");
@@ -238,7 +248,7 @@ await import(${JSON.stringify(join(repoRoot, "scripts", "serve-static.ts"))});
 	expect(positionalResult.stdout).toContain("Serving public on http://0.0.0.0:NaN");
 });
 
-test("generate-small-mock defaults to a tmpdir output and accepts a first positional", async () => {
+cliTest("generate-small-mock defaults to a tmpdir output and accepts a first positional", async () => {
 	// Given
 	const root = await tempRoot("vibe-tavern-small-mock-");
 	const custom = "--custom-mock";

--- a/scripts/test-report.test.ts
+++ b/scripts/test-report.test.ts
@@ -52,6 +52,18 @@ describe("final test report", () => {
 		expect(report.trimEnd().endsWith(expectedFinalLine)).toBe(true);
 	});
 
+	test("reports elapsed time alongside suite time when suites overlapped", () => {
+		// Given: suites summing to 60ms that a pool finished in 40ms of wall clock.
+		// Reporting only the sum would claim a parallel run took longer than it did.
+		const expectedFinalLine = "Suites: 2 passed, 1 failed | Time: 40ms (60ms of suite time)";
+
+		// When
+		const report = formatTestReport(results, 40);
+
+		// Then
+		expect(report.trimEnd().endsWith(expectedFinalLine)).toBe(true);
+	});
+
 	test("extracts Bun assertion output without unrelated test warnings", () => {
 		// Given
 		const noisyFailure = [{

--- a/scripts/test-report.ts
+++ b/scripts/test-report.ts
@@ -64,11 +64,19 @@ function formatFailure(result: TestSuiteResult): string {
 	return [`--- ${result.name} ---`, ...output].join("\n\n");
 }
 
-export function formatTestReport(results: readonly TestSuiteResult[]): string {
+/**
+ * `wallClockMs` is the elapsed time of the whole run. Suites run several at a
+ * time, so the sum of their durations overstates it — pass the measured elapsed
+ * time and the summary reports both. Omitted, the sum is the only number there is.
+ */
+export function formatTestReport(results: readonly TestSuiteResult[], wallClockMs?: number): string {
 	const failures = results.filter((result) => result.exitCode !== 0);
 	const passed = results.length - failures.length;
 	const nameWidth = Math.max(0, ...results.map((result) => result.name.length));
-	const totalDurationMs = results.reduce((total, result) => total + result.durationMs, 0);
+	const suiteDurationMs = results.reduce((total, result) => total + result.durationMs, 0);
+	const time = wallClockMs === undefined
+		? formatDuration(suiteDurationMs)
+		: `${formatDuration(wallClockMs)} (${formatDuration(suiteDurationMs)} of suite time)`;
 	const lines: string[] = [];
 
 	if (failures.length > 0) {
@@ -80,6 +88,6 @@ export function formatTestReport(results: readonly TestSuiteResult[]): string {
 		const status = result.exitCode === 0 ? "PASS" : "FAIL";
 		lines.push(`${status}  ${result.name.padEnd(nameWidth)}  ${formatDuration(result.durationMs)}`);
 	}
-	lines.push("", `Suites: ${passed} passed, ${failures.length} failed | Time: ${formatDuration(totalDurationMs)}`);
+	lines.push("", `Suites: ${passed} passed, ${failures.length} failed | Time: ${time}`);
 	return lines.join("\n");
 }

--- a/scripts/test-web.test.ts
+++ b/scripts/test-web.test.ts
@@ -43,13 +43,13 @@ async function runCli(root: string, args: readonly string[]): Promise<CliResult>
 	return { exitCode, output: output.join("\n"), errors: errors.join("\n") };
 }
 
-test("gives each web test file more headroom on Windows only", () => {
-	// Same hazard as the packages/services suites: a slow Windows runner blows
-	// through bun's default 5s per-test timeout. See scripts/test.ts.
-	const windows = createWebTestFileCommand("a.test.tsx", "report.xml", "win32");
-	expect(windows).toContain("--timeout");
-	expect(windows).toContain("15000");
-	expect(createWebTestFileCommand("a.test.tsx", "report.xml", "linux")).not.toContain("--timeout");
+test("gives each web test file the same timeout headroom on every platform", () => {
+	// Same hazard as the packages/services suites: a loaded runner blows through
+	// bun's default 5s per-test timeout. Windows is the worst case, but suites now
+	// run several at a time, so contention reaches Linux too. See scripts/test.ts.
+	const command = createWebTestFileCommand("a.test.tsx", "report.xml");
+	expect(command).toContain("--timeout");
+	expect(command).toContain("15000");
 });
 
 test("discovers normalized source tests in lexical order and appends the harness canary", async () => {

--- a/scripts/test-web.ts
+++ b/scripts/test-web.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { parseArgs } from "node:util";
-import { windowsTimeoutArgs } from "./test.js";
+import { testTimeoutArgs } from "./test.js";
 
 interface TestFileResult {
 	readonly file: string;
@@ -85,16 +85,12 @@ async function validateFiles(root: string, files: readonly string[], write: Outp
 	return true;
 }
 
-/** Per-file `bun test` invocation. Windows headroom: see scripts/test.ts. */
-export function createWebTestFileCommand(
-	file: string,
-	reportPath: string,
-	platform: NodeJS.Platform = process.platform,
-): readonly string[] {
+/** Per-file `bun test` invocation. Timeout headroom: see scripts/test.ts. */
+export function createWebTestFileCommand(file: string, reportPath: string): readonly string[] {
 	return [
 		process.execPath,
 		"test",
-		...windowsTimeoutArgs(platform),
+		...testTimeoutArgs(),
 		file,
 		"--reporter=junit",
 		"--reporter-outfile",

--- a/scripts/test.test.ts
+++ b/scripts/test.test.ts
@@ -6,6 +6,7 @@ import {
 	createTestSuites,
 	runTestCli,
 	runTestSuites,
+	suiteConcurrency,
 	type TestSuite,
 } from "./test.js";
 
@@ -51,33 +52,120 @@ describe("test suite orchestration", () => {
 		}
 	});
 
-	test("gives every bun:test suite more headroom on Windows only", () => {
-		// Windows runners are slow enough that bun's default 5s per-test timeout
-		// trips on any suite that touches SQLite and the filesystem — `db` was
-		// only the first one to hit it, `api` (avatar adapter) was the second.
-		const windows = createTestSuites("win32").filter((suite) => suite.command[1] === "test");
-		expect(windows.map((suite) => suite.name)).toEqual([
-			"scripts",
-			"domain",
-			"api-contracts",
-			"prompt-pipeline",
-			"import-export",
-			"db",
+	test("gives every bun:test suite the same timeout headroom on every platform", () => {
+		// A loaded runner blows through bun's default 5s per-test timeout on any
+		// suite that touches SQLite and the filesystem — `db` was the first to hit
+		// it, `api` (avatar adapter) the second. Windows is the worst case, but the
+		// pool in runTestSuites puts several suites on the box at once, so the same
+		// contention reaches Linux; the headroom is unconditional.
+		const bunTestSuites = createTestSuites().filter((suite) => suite.command[1] === "test");
+		expect(bunTestSuites.map((suite) => suite.name)).toEqual([
 			"api",
+			"db",
+			"scripts",
+			"prompt-pipeline",
+			"api-contracts",
+			"import-export",
+			"domain",
 		]);
-		for (const suite of windows) {
+		for (const suite of bunTestSuites) {
 			expect(suite.command).toContain("--timeout");
 			expect(suite.command).toContain("15000");
 		}
+	});
 
-		for (const suite of createTestSuites("linux")) {
-			expect(suite.command).not.toContain("--timeout");
-		}
+	test("declares the long suites first so the pool never trails a late starter", () => {
+		// `web` fans out to its own 8-way subprocess pool and is the longest suite
+		// on Linux; declared last it would start last and run alone at the tail.
+		expect(createTestSuites().map((suite) => suite.name).slice(0, 3)).toEqual(["web", "api", "db"]);
 	});
 
 	test("keeps bun test flags ahead of the positional filter", () => {
-		const scripts = createTestSuites("win32").find((suite) => suite.name === "scripts");
+		const scripts = createTestSuites().find((suite) => suite.name === "scripts");
 		expect(scripts?.command.at(-1)).toBe("scripts");
+	});
+
+	test("drops the platform-agnostic web suite from a bare run on Windows only", () => {
+		// 160 of web's 162 files are React components and stores; two touch the
+		// filesystem. On a runner where every syscall costs 2–4× Linux that is ~83s
+		// for no platform coverage. Naming the suite still runs it there.
+		const suites = createTestSuites();
+		expect(suites.find((suite) => suite.name === "web")?.skipOnWindows).toBe(true);
+		for (const suite of suites) {
+			if (suite.name !== "web") expect(suite.skipOnWindows).toBeUndefined();
+		}
+	});
+
+	test("skips a windows-only suite on win32 but still runs it when named", async () => {
+		// Given
+		const probe = { name: "probe", cwd, command: [process.execPath, "-e", "process.exit(0)"], skipOnWindows: true } as const;
+		const keep = { name: "keep", cwd, command: [process.execPath, "-e", "process.exit(0)"] } as const;
+		const suites = [probe, keep] as const satisfies readonly TestSuite[];
+
+		// When
+		const bare: string[] = [];
+		const named: string[] = [];
+		const linux: string[] = [];
+		await runTestCli(suites, [], (message) => bare.push(message), "win32");
+		await runTestCli(suites, ["probe"], (message) => named.push(message), "win32");
+		await runTestCli(suites, [], (message) => linux.push(message), "linux");
+
+		// Then
+		expect(bare.join("\n")).toContain("Skipping on win32: probe");
+		expect(bare.join("\n")).toContain("Running 1 isolated test suites");
+		expect(named.join("\n")).toContain("[1/1] probe");
+		expect(named.join("\n")).not.toContain("Skipping on win32");
+		expect(linux.join("\n")).toContain("Running 2 isolated test suites");
+		expect(linux.join("\n")).not.toContain("Skipping");
+	});
+
+	test("runs suites concurrently instead of one at a time", async () => {
+		// Given: two suites that each sleep, so a sequential runner takes twice as
+		// long as a parallel one. Pinned on overlap, not wall clock — a loaded CI
+		// box can stretch either number, but only a sequential runner serialises them.
+		const sleeper = (name: string) => ({
+			name,
+			cwd,
+			command: [
+				process.execPath,
+				"-e",
+				`console.log(Date.now()); await Bun.sleep(400); console.log(Date.now())`,
+			],
+		});
+		const suites = [sleeper("first"), sleeper("second")] as const satisfies readonly TestSuite[];
+
+		// When
+		const results = await runTestSuites(suites, undefined, { concurrency: 2 });
+
+		// Then: the two windows overlap.
+		const spans = results.map((result) => result.stdout.trim().split("\n").map(Number));
+		const [firstStart, firstEnd] = [spans[0]?.[0] ?? 0, spans[0]?.[1] ?? 0];
+		const [secondStart, secondEnd] = [spans[1]?.[0] ?? 0, spans[1]?.[1] ?? 0];
+		expect(firstStart).toBeLessThan(secondEnd);
+		expect(secondStart).toBeLessThan(firstEnd);
+	});
+
+	test("keeps results in declaration order when suites finish out of order", async () => {
+		// Given: the first suite outlives the second, so a pool completes them backwards.
+		const suites = [
+			{ name: "slow", cwd, command: [process.execPath, "-e", 'await Bun.sleep(300); console.log("slow")'] },
+			{ name: "fast", cwd, command: [process.execPath, "-e", 'console.log("fast")'] },
+		] as const satisfies readonly TestSuite[];
+
+		// When
+		const results = await runTestSuites(suites, undefined, { concurrency: 2 });
+
+		// Then
+		expect(results.map((result) => result.name)).toEqual(["slow", "fast"]);
+		expect(results[0]?.stdout).toContain("slow");
+		expect(results[1]?.stdout).toContain("fast");
+	});
+
+	test("caps the pool at half the cores, between 2 and 4", () => {
+		expect(suiteConcurrency(1)).toBe(2);
+		expect(suiteConcurrency(4)).toBe(2);
+		expect(suiteConcurrency(6)).toBe(3);
+		expect(suiteConcurrency(16)).toBe(4);
 	});
 
 	test("continues after a failed suite and captures every result", async () => {
@@ -180,7 +268,7 @@ describe("test suite orchestration", () => {
 
 		// Then
 		expect(exitCode).toBe(0);
-		expect(output).toContain("Running 2 isolated test suites...");
+		expect(output.join("\n")).toContain("Running 2 isolated test suites");
 		expect(output).toContain("[1/2] first");
 		expect(output).toContain("[2/2] second");
 	});

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { availableParallelism, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { formatTestReport, type TestSuiteResult } from "./test-report.js";
@@ -10,6 +10,12 @@ export interface TestSuite {
 	readonly name: string;
 	readonly cwd: string;
 	readonly command: readonly string[];
+	/**
+	 * Dropped from a bare `bun run test` on Windows, where every syscall costs
+	 * 2–4× what it does on Linux and this suite has no platform-specific
+	 * behaviour to pin. Naming it (`bun run test web`) still runs it anywhere.
+	 */
+	readonly skipOnWindows?: boolean;
 }
 
 export type TestSuiteStartHandler = (suite: TestSuite, index: number, total: number) => void;
@@ -19,66 +25,76 @@ const ROOT = resolve(import.meta.dir, "..");
 const BUN = process.execPath;
 
 /**
- * Windows CI runners are slow enough that bun's default 5s per-test timeout
- * trips on tests that only do a normal amount of SQLite + filesystem work
- * (a `mkdtemp` + full migration stack per test costs milliseconds on Linux and
- * seconds there). This is a runner-speed floor, not a product budget, so every
- * `bun test` invocation gets the same headroom on win32 and the default
- * everywhere else.
+ * Per-test timeout for every `bun test` invocation. Bun's 5s default is a
+ * product-sized budget; these suites run several at a time (see
+ * `runTestSuites`) on shared CI runners, so a test doing a normal amount of
+ * SQLite + filesystem work can lose seconds to contention alone. Windows is the
+ * worst case — a `mkdtemp` + full migration stack costs milliseconds on Linux
+ * and seconds there — but the floor is machine speed under load, not platform,
+ * so the headroom is unconditional.
  */
-export const WINDOWS_TEST_TIMEOUT_MS = 15_000;
+export const TEST_TIMEOUT_MS = 15_000;
 
-export function windowsTimeoutArgs(platform: NodeJS.Platform): readonly string[] {
-	return platform === "win32" ? ["--timeout", String(WINDOWS_TEST_TIMEOUT_MS)] : [];
+export function testTimeoutArgs(): readonly string[] {
+	return ["--timeout", String(TEST_TIMEOUT_MS)];
 }
 
 /** `bun test` invocation for one suite. Flags precede the positional filter. */
-function bunTestCommand(platform: NodeJS.Platform, ...positionals: readonly string[]): readonly string[] {
-	return [BUN, "test", "--only-failures", ...windowsTimeoutArgs(platform), ...positionals];
+function bunTestCommand(...positionals: readonly string[]): readonly string[] {
+	return [BUN, "test", "--only-failures", ...testTimeoutArgs(), ...positionals];
 }
 
-export function createTestSuites(platform: NodeJS.Platform = process.platform): readonly TestSuite[] {
+/**
+ * Declared longest-first. `runTestSuites` hands these to a worker pool in this
+ * order, so a long suite declared last would start last and run alone at the
+ * tail; the ranking is what keeps the pool busy to the end.
+ */
+export function createTestSuites(): readonly TestSuite[] {
 	return [
 		{
-			name: "scripts",
-			cwd: ROOT,
-			command: bunTestCommand(platform, "scripts"),
-		},
-		{
-			name: "domain",
-			cwd: join(ROOT, "packages", "domain"),
-			command: bunTestCommand(platform),
-		},
-		{
-			name: "api-contracts",
-			cwd: join(ROOT, "packages", "api-contracts"),
-			command: bunTestCommand(platform),
-		},
-		{
-			name: "prompt-pipeline",
-			cwd: join(ROOT, "packages", "prompt-pipeline"),
-			command: bunTestCommand(platform),
-		},
-		{
-			name: "import-export",
-			cwd: join(ROOT, "packages", "import-export"),
-			command: bunTestCommand(platform),
-		},
-		{
-			name: "db",
-			cwd: join(ROOT, "packages", "db"),
-			command: bunTestCommand(platform),
+			// Runs each file in its own subprocess — the timeout lives in scripts/test-web.ts.
+			// 160+ of its 162 files are React components and stores; exactly two touch
+			// `node:fs`/`node:path`/`process.platform`, so it buys no Windows coverage
+			// for the ~83s it costs there.
+			name: "web",
+			cwd: join(ROOT, "apps", "web"),
+			command: [BUN, "run", "test"],
+			skipOnWindows: true,
 		},
 		{
 			name: "api",
 			cwd: join(ROOT, "services", "api"),
-			command: bunTestCommand(platform),
+			command: bunTestCommand(),
 		},
 		{
-			// Runs each file in its own subprocess — the timeout lives in scripts/test-web.ts.
-			name: "web",
-			cwd: join(ROOT, "apps", "web"),
-			command: [BUN, "run", "test"],
+			name: "db",
+			cwd: join(ROOT, "packages", "db"),
+			command: bunTestCommand(),
+		},
+		{
+			name: "scripts",
+			cwd: ROOT,
+			command: bunTestCommand("scripts"),
+		},
+		{
+			name: "prompt-pipeline",
+			cwd: join(ROOT, "packages", "prompt-pipeline"),
+			command: bunTestCommand(),
+		},
+		{
+			name: "api-contracts",
+			cwd: join(ROOT, "packages", "api-contracts"),
+			command: bunTestCommand(),
+		},
+		{
+			name: "import-export",
+			cwd: join(ROOT, "packages", "import-export"),
+			command: bunTestCommand(),
+		},
+		{
+			name: "domain",
+			cwd: join(ROOT, "packages", "domain"),
+			command: bunTestCommand(),
 		},
 	];
 }
@@ -128,6 +144,19 @@ async function runTestSuite(suite: TestSuite, testTempRoot: string): Promise<Tes
 export interface TestRunOptions {
 	/** Existing directory used as the parent for this run's disposable temp root. */
 	readonly tempBase?: string;
+	/** How many suites may run at once. Defaults to `suiteConcurrency()`. */
+	readonly concurrency?: number;
+}
+
+/**
+ * Half the cores, floored at 2 and capped at 4. `web` fans its own files out to
+ * 8 subprocesses, so the pool only has to keep the single-process suites (`api`,
+ * `db`, `scripts`) off the critical path — past ~3 the runner is saturated and
+ * extra slots only add contention. Measured on a 4-core box (`taskset -c 0-3`):
+ * 69.1s sequential, 50.9s at 2 and 3, 53.7s at 4.
+ */
+export function suiteConcurrency(cores: number = availableParallelism()): number {
+	return Math.max(2, Math.min(4, Math.floor(cores / 2)));
 }
 
 export async function runTestSuites(
@@ -138,13 +167,22 @@ export async function runTestSuites(
 	const tempBase = resolve(options.tempBase ?? Bun.env.VIBE_TAVERN_TEST_TEMP_BASE ?? tmpdir());
 	await mkdir(tempBase, { recursive: true });
 	const testTempRoot = await mkdtemp(join(tempBase, "vibe-tavern-test-run-"));
-	const results: TestSuiteResult[] = [];
+	// Indexed rather than pushed: suites finish out of order, the report must not.
+	const results: Array<TestSuiteResult | undefined> = Array.from({ length: suites.length });
+	const poolSize = Math.max(1, Math.min(options.concurrency ?? suiteConcurrency(), suites.length));
+	let next = 0;
 	try {
-		for (const [index, suite] of suites.entries()) {
-			onStart?.(suite, index, suites.length);
-			results.push(await runTestSuite(suite, testTempRoot));
-		}
-		return results;
+		await Promise.all(
+			Array.from({ length: poolSize }, async () => {
+				for (let index = next++; index < suites.length; index = next++) {
+					const suite = suites[index];
+					if (suite === undefined) continue;
+					onStart?.(suite, index, suites.length);
+					results[index] = await runTestSuite(suite, testTempRoot);
+				}
+			}),
+		);
+		return results.flatMap((result) => (result === undefined ? [] : [result]));
 	} finally {
 		await rm(testTempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
 	}
@@ -154,9 +192,16 @@ type TestSuiteSelection =
 	| { readonly kind: "selected"; readonly suites: readonly TestSuite[] }
 	| { readonly kind: "error"; readonly message: string };
 
-function selectTestSuites(suites: readonly TestSuite[], args: readonly string[]): TestSuiteSelection {
+function selectTestSuites(
+	suites: readonly TestSuite[],
+	args: readonly string[],
+	platform: NodeJS.Platform,
+): TestSuiteSelection {
 	if (args.length === 0) {
-		return { kind: "selected", suites };
+		return {
+			kind: "selected",
+			suites: platform === "win32" ? suites.filter((suite) => suite.skipOnWindows !== true) : suites,
+		};
 	}
 
 	const suitesByName = new Map(suites.map((suite) => [suite.name, suite]));
@@ -189,18 +234,24 @@ export async function runTestCli(
 	suites: readonly TestSuite[],
 	args: readonly string[],
 	write: TestOutputWriter,
+	platform: NodeJS.Platform = process.platform,
 ): Promise<number> {
-	const selection = selectTestSuites(suites, args);
+	const selection = selectTestSuites(suites, args, platform);
 	switch (selection.kind) {
 		case "error":
 			write(selection.message);
 			return 1;
 		case "selected": {
-			write(`Running ${selection.suites.length} isolated test suites...`);
+			const skipped = args.length === 0 ? suites.filter((suite) => !selection.suites.includes(suite)) : [];
+			if (skipped.length > 0) {
+				write(`Skipping on ${platform}: ${skipped.map((suite) => suite.name).join(", ")}`);
+			}
+			write(`Running ${selection.suites.length} isolated test suites (max ${suiteConcurrency()} at a time)...`);
+			const startedAt = performance.now();
 			const results = await runTestSuites(selection.suites, (suite, index, total) => {
 				write(`[${index + 1}/${total}] ${suite.name}`);
 			});
-			write(`\n${formatTestReport(results)}`);
+			write(`\n${formatTestReport(results, Math.round(performance.now() - startedAt))}`);
 			return results.some((result) => result.exitCode !== 0) ? 1 : 0;
 		}
 		default: {


### PR DESCRIPTION
Baseline [31267119462](https://github.com/Noineri/vibe_tavern/actions/runs/31267119462): `test-windows` was 5m18s of a 5m24s run, and the same suite gates every release — `verify-windows` blocks all four builds in `release.yml`.

| suite | Windows | Linux | ratio |
|---|---|---|---|
| scripts | 28.8s | 6.7s | 4.3× |
| db | 67.6s | 17.6s | 3.8× |
| api | 64.1s | 28.2s | 2.3× |
| web | 83.2s | 43.6s | 1.9× |
| four small ones | 0.65s | 0.4s | — |
| **total** | **244.4s** | **96.4s** | 2.5× |

The sum equalled the total on both platforms — there was no parallelism at all.

## Result

| | baseline | final ([31385205174](https://github.com/Noineri/vibe_tavern/actions/runs/31385205174)) |
|---|---|---|
| **whole CI run** | **5m24s** | **2m58s** |
| test-windows | 5m18s | 2m53s |
| ↳ `bun run test` | 247s | 69–117s |
| build-windows | 4m28s | 2m02s |
| ↳ `build-installer` | 108s | **16s** |

Four runs on this branch: 4m27s → 4m11s → 3m05s → 2m58s, all green.

## Changes

**Suites run in a pool.** The `for` loop in `runTestSuites` put `db`, `api` and `scripts` on one core of four, back to back; only `web` parallelised, internally. `suiteConcurrency()` is half the cores, floored at 2 and capped at 4. On a 4-core box (`taskset -c 0-3`): 69.1s sequential → 50.9s at 2 and 3, 53.7s at 4; CPU 228% → 317% of 400%. Suites are declared longest-first — `web` fans out to its own 8-way subprocess pool and declared last would start last and run alone at the tail.

**Windows stops paying for coverage it does not need.** Declared in the test code, never in the workflow, so `bun run test` on a Windows dev box behaves like CI:

| skipped on win32 | declared at | why |
|---|---|---|
| the `web` suite | `skipOnWindows` in `scripts/test.ts` | 160 of its 162 files are React components and stores; two touch `node:fs`/`node:path`/`process.platform`. ~83s for no platform coverage. `bun run test web` still runs it there. |
| `scripts/cli-args.test.ts` | `test.skipIf` | nine cases that each spawn a full `bun` to pin argv parsing — pure Bun/Node semantics |
| `scripts/bump-version.test.ts` | `describe.skipIf` | builds a disposable workspace and two git repos per case; the release script it covers only ever runs on the Linux release job |

`scripts` goes 28.8s → 2.7s: those two files were ~90% of the suite.

**CI stops compressing an installer it throws away.** With the tests down, `build-windows` set the floor. Its log: ~53s install, ~13s standalone build, **~95s Inno Setup**, ~29s windows-dist — and 48 of those 95 seconds were one line, compressing the ~100 MB `vibe-tavern.exe` at `lzma2/ultra64` into a solid block. CI never uploads that installer (no `upload-artifact` step; the note at the top of `ci.yml` says so) — it exists to prove the thing compiles. Compression is now a define with the shipped values as defaults, and CI passes `--fast-compression`. `Successful compile (3.875 sec)`, down from ~95s.

The compile still verifies what it always did: the script parses, every `[Files]` entry resolves, `[Code]` compiles. What CI stops exercising is the LZMA pass, which `release.yml` runs at full settings on every tag. **`release.yml` is deliberately untouched** — and it needs no port: `verify-windows` calls `bun run test`, so it picks up the pool and the skips for free.

`none` rather than a level like `lzma2/fast` because ISPP evaluates `/D` values as expressions and a `/` in one is a division operator. A test pins every override to a bare identifier, since that failure would surface as ISCC choking on a line nobody edited.

## Consequences handled rather than papered over

- **The 15s per-test timeout is now unconditional.** It was win32-only. Running suites concurrently reproduces the same failure on Linux — under a 4-way pool `cli-args` timed out at 5000ms and its child died on SIGTERM. The floor is machine speed under load, not platform. `WINDOWS_TEST_TIMEOUT_MS`/`windowsTimeoutArgs` → `TEST_TIMEOUT_MS`/`testTimeoutArgs`.
- **The summary line summed suite durations**, overstating a parallel run — `Time: 101.5s` for a run that took 52s. `formatTestReport` now takes measured elapsed time and prints both: `Time: 26.6s (65.3s of suite time)`.
- **`build-installer.ts` ran `main()` on import**, so importing `isccArgs` for a test would have kicked off a real installer build. Guarded behind `import.meta.main`.

## Two things that did not work, kept here so nobody retries them

**Disabling Defender bought nothing.** It was in this PR and has been removed. A probe confirmed the preference applies (`RealTimeProtectionEnabled: False`, `IsTamperProtected: False`) — not a Tamper Protection no-op — but applying is not helping: `bun install` ran 43–101s across 10 runs without it and 44–61s across 4 with it, entirely inside the noise, while the step itself cost 5–12s per job.

**Never conclude anything from a single Windows run.** Two runs of identical test code minutes apart reported `api` at 115.5s and 68.5s and `db` at 103.4s and 62.7s — `eastus` against `northcentralus`. That is the difference between the pool buying 12% and buying 47%, decided by which machine GitHub hands out. Written into `testing.md`.

## Verification

`bun run typecheck` and `bun run test` green; four green CI runs. The `scripts` suite goes 59 → 71 tests: pool overlap, result ordering when suites finish out of order, `suiteConcurrency` bounds, the win32 filter (skipped bare, still runs when named), longest-first declaration, the wall-clock report line, and four pins on the ISCC command line.

## Left alone

- **`bun install` is now the single biggest Windows cost** — 73s in `build-windows`, 61s in `test-windows`, against 3.7s on Linux. Defender is ruled out; 26 500 files on NTFS, bun's link backend and runner disk speed are not. Not investigated.
- `needs: [typecheck]` on `build-windows` — ~26s of waiting, but removing it weakens the gate.
- `build-windows-dist.ts` rebuilds the frontend `build-installer.ts` already built in the same job, identical content hashes — ~8s.
- `.js.map` files go into the shipped installer — size of a real artifact, a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)