### PR TITLE
fix(test): report uncaught Bun test errors

### DIFF
--- a/scripts/test-report.test.ts
+++ b/scripts/test-report.test.ts
@@ -41,6 +41,26 @@ describe("final test report", () => {
 		}
 	});
 
+	test("bounds unrecognized fallback output", () => {
+		// Given: a failed suite that produces one oversized line in each output stream.
+		const oversizedFallback = [{
+			name: "fallback",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "stdout ".concat("x".repeat(200_000)),
+			stderr: "stderr ".concat("y".repeat(200_000)),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(oversizedFallback);
+
+		// Then: both streams retain their labels without making the report unbounded.
+		expect(report).toContain("[stdout]");
+		expect(report).toContain("[stderr]");
+		expect(report).toContain("... output truncated after 2000 characters");
+		expect(report.length).toBeLessThan(4_500);
+	});
+
 	test("places the aggregate result at the bottom", () => {
 		// Given
 		const expectedFinalLine = "Suites: 2 passed, 1 failed | Time: 60ms";
@@ -95,5 +115,376 @@ describe("final test report", () => {
 		expect(report).toContain("Expected: 1");
 		expect(report).toContain("Received: 2");
 		expect(report).not.toContain("repeated setup warning");
+	});
+
+	/**
+	 * Real CI failure: `services/api` exited 1 on `0 fail` with 8 uncaught
+	 * throws. Anchored on `(fail)` alone there was nothing to extract, so the
+	 * report fell back to the last 120 lines of a 142-file run — the throws had
+	 * printed hundreds of lines earlier and the log carried no trace of them.
+	 */
+	test("extracts throws Bun could not attribute to a test", () => {
+		// Given: a suite that failed on uncaught errors, not on a failed assertion.
+		const uncaughtFailure = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "[db] Migrations folder: /repo/packages/db/drizzle\n",
+			stderr: [
+				"test/early.test.ts:",
+				"5 | setTimeout(() => { throw new Error(\"late boom\"); }, 20);",
+				"error: late boom",
+				"      at <anonymous> (/repo/services/api/test/early.test.ts:5:24)",
+				"",
+				"test/quiet.test.ts:",
+				"[quota] poll failed for profile prov_0001 (network)",
+				"",
+				"test/late.test.ts:",
+				"TypeError: undefined is not a function",
+				"      at <anonymous> (/repo/services/api/test/late.test.ts:9:3)",
+				"",
+				" 1861 pass",
+				" 9 skip",
+				" 0 fail",
+				" 8 errors",
+				" 4948 expect() calls",
+				"Ran 1870 tests across 142 files. [67.96s]",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(uncaughtFailure);
+
+		// Then: both throws survive, with the file that raised each one.
+		expect(report).toContain("test/early.test.ts:");
+		expect(report).toContain("error: late boom");
+		expect(report).toContain("test/late.test.ts:");
+		expect(report).toContain("TypeError: undefined is not a function");
+		// And the tally that explains the non-zero exit.
+		expect(report).toContain("8 errors");
+		// And a file that merely logged something error-shaped stays out.
+		expect(report).not.toContain("test/quiet.test.ts:");
+		expect(report).not.toContain("[quota] poll failed");
+	});
+
+	test("bounds an unhandled diagnostic excerpt", () => {
+		// Given: a throwable diagnostic followed by enough noise to make a full
+		// section unsuitable for an actionable terminal report.
+		const oversizedDiagnostic = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/oversized.test.ts:",
+				"error: late boom",
+				"      at <anonymous> (/repo/services/api/test/oversized.test.ts:5:24)",
+				...Array.from({ length: 121 }, (_, index) => `unrelated output ${index}`),
+				" 1 pass",
+				" 0 fail",
+				" 1 error",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(oversizedDiagnostic);
+
+		// Then: the error remains actionable but the unbounded tail is omitted.
+		expect(report).toContain("error: late boom");
+		expect(report).toContain("... diagnostic output truncated after");
+		expect(report).not.toContain("unrelated output 60");
+	});
+
+	test("keeps a failed assertion at the end of an oversized test section", () => {
+		// Given: a test section with more preamble than the diagnostic line budget.
+		const buriedAssertion = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/buried.test.ts:",
+				...Array.from({ length: 121 }, (_, index) => `setup output ${index}`),
+				"error: buried boom",
+				"(fail) buried > fails",
+				" 0 pass",
+				" 1 fail",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(buriedAssertion);
+
+		// Then: the actionable failure remains visible after bounded compaction.
+		expect(report).toContain("error: buried boom");
+		expect(report).toContain("(fail) buried > fails");
+	});
+
+	test("extracts uncaught diagnostics written to stdout", () => {
+		// Given: Bun's console reporter sends the diagnostic to stdout.
+		const stdoutFailure = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: [
+				"test/stdout.test.ts:",
+				"error: stdout boom",
+				"      at <anonymous> (/repo/services/api/test/stdout.test.ts:5:24)",
+				" 1 pass",
+				" 0 fail",
+				" 1 error",
+			].join("\n"),
+			stderr: "",
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(stdoutFailure);
+
+		// Then: the console diagnostic is preserved without a fallback wrapper.
+		expect(report).toContain("test/stdout.test.ts:");
+		expect(report).toContain("error: stdout boom");
+		expect(report).not.toContain("[stdout]");
+	});
+
+	test("keeps actionable diagnostics from both output streams", () => {
+		// Given: separate unhandled errors written to stdout and stderr.
+		const mixedStreamFailure = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: [
+				"test/stdout.test.ts:",
+				"error: stdout boom",
+				"      at <anonymous> (/repo/services/api/test/stdout.test.ts:5:24)",
+			].join("\n"),
+			stderr: [
+				"test/stderr.test.ts:",
+				"error: stderr boom",
+				"      at <anonymous> (/repo/services/api/test/stderr.test.ts:9:24)",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(mixedStreamFailure);
+
+		// Then: neither diagnostic is discarded because another stream was actionable.
+		expect(report).toContain("error: stdout boom");
+		expect(report).toContain("error: stderr boom");
+	});
+
+	test("keeps an error tally from the other output stream", () => {
+		// Given: stdout has the error detail while stderr has Bun's final tally.
+		const splitSummaryFailure = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: [
+				"test/stdout.test.ts:",
+				"error: stdout boom",
+				"      at <anonymous> (/repo/services/api/test/stdout.test.ts:5:24)",
+			].join("\n"),
+			stderr: [" 1 pass", " 0 fail", " 1 error"].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(splitSummaryFailure);
+
+		// Then: the tally still explains the non-zero exit.
+		expect(report).toContain("1 pass");
+		expect(report).toContain("0 fail");
+		expect(report).toContain("1 error");
+	});
+
+	test("bounds a single oversized diagnostic line", () => {
+		// Given: one diagnostic line substantially exceeds the report's character budget.
+		const oversizedLine = "x".repeat(200_000);
+		const oversizedDiagnostic = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/oversized-line.test.ts:",
+				"error: late boom",
+				"      at <anonymous> (/repo/services/api/test/oversized-line.test.ts:5:24)",
+				oversizedLine,
+				" 1 pass",
+				" 0 fail",
+				" 1 error",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(oversizedDiagnostic);
+
+		// Then: the report remains bounded while retaining the diagnostic context and tally.
+		expect(report).toContain("error: late boom");
+		expect(report).toContain("... diagnostic output truncated after 2000 characters");
+		expect(report).toContain("1 error");
+		expect(report.length).toBeLessThan(3_000);
+	});
+
+	test("keeps a later unhandled error after an oversized diagnostic", () => {
+		// Given: early diagnostic noise that would otherwise consume the whole report.
+		const multipleDiagnostics = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/early.test.ts:",
+				"error: early boom",
+				"      at <anonymous> (/repo/services/api/test/early.test.ts:5:24)",
+				...Array.from({ length: 121 }, (_, index) => `early noise ${index}`),
+				"test/late.test.ts:",
+				"TypeError: late boom",
+				"      at <anonymous> (/repo/services/api/test/late.test.ts:9:3)",
+				" 1 pass",
+				" 0 fail",
+				" 2 errors",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(multipleDiagnostics);
+
+		// Then: the later throw remains visible despite the oversized early section.
+		expect(report).toContain("error: early boom");
+		expect(report).toContain("TypeError: late boom");
+		expect(report).toContain("2 errors");
+	});
+
+	test("drops unterminated terminal strings", () => {
+		// Given: repeated unclosed OSC introducers after an otherwise valid diagnostic.
+		const unterminatedControls = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/terminal.test.ts:",
+				"error: late boom",
+				"      at <anonymous> (/repo/services/api/test/terminal.test.ts:5:24)",
+				"\u001B]unclosed".repeat(10_000),
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(unterminatedControls);
+
+		// Then: the report keeps the real diagnostic without terminal-string payload.
+		expect(report).toContain("error: late boom");
+		expect(report).not.toContain("unclosed");
+	});
+
+	test("removes terminal controls from an unhandled diagnostic", () => {
+		// Given: diagnostic text containing OSC and DCS strings plus a carriage return.
+		const terminalControls = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/terminal.test.ts:",
+				"error: late boom\u001B]8;;https://untrusted.example\u0007\u001BPuntrusted DCS\u001B\\",
+				"      at <anonymous> (/repo/services/api/test/terminal.test.ts:5:24)\rrewritten",
+				" 1 pass",
+				" 0 fail",
+				" 1 error",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(terminalControls);
+
+		// Then: the useful error and stack survive without terminal instructions.
+		expect(report).toContain("error: late boom");
+		expect(report).toContain("rewritten");
+		expect(report).not.toContain("https://untrusted.example");
+		expect(report).not.toContain("untrusted DCS");
+		expect(report).not.toContain("\u001B");
+		expect(report).not.toContain("\r");
+	});
+
+	test("ends a terminal string at C1 ST without swallowing the next error", () => {
+		// Given: an OSC sequence closed by U+009C before another unhandled error.
+		const c1TerminatedControl = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/first.test.ts:",
+				"error: before boom\u001B]8;;https://untrusted.example\u009C",
+				"      at <anonymous> (/repo/services/api/test/first.test.ts:5:24)",
+				"test/second.test.ts:",
+				"error: after boom",
+				"      at <anonymous> (/repo/services/api/test/second.test.ts:9:24)",
+				" 2 errors",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(c1TerminatedControl);
+
+		// Then: the control payload is removed while the later diagnostic and tally remain.
+		expect(report).toContain("error: after boom");
+		expect(report).toContain("2 errors");
+		expect(report).not.toContain("https://untrusted.example");
+	});
+
+	test("removes C1 terminal strings", () => {
+		// Given: terminal strings introduced and terminated by C1 control bytes.
+		const c1IntroducedOsc = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/terminal.test.ts:",
+				"error: late boom\u0090untrusted DCS\u009C\u0098untrusted SOS\u009C\u009Dhttps://untrusted.example\u0007\u009Euntrusted PM\u009C\u009Funtrusted APC\u009C",
+				"      at <anonymous> (/repo/services/api/test/terminal.test.ts:5:24)",
+				" 1 error",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(c1IntroducedOsc);
+
+		// Then: every control payload is removed without losing the diagnostic or tally.
+		expect(report).toContain("error: late boom");
+		expect(report).toContain("1 error");
+		expect(report).not.toContain("untrusted DCS");
+		expect(report).not.toContain("untrusted SOS");
+		expect(report).not.toContain("https://untrusted.example");
+		expect(report).not.toContain("untrusted PM");
+		expect(report).not.toContain("untrusted APC");
+	});
+
+	test("ends a DCS string at C1 ST without swallowing the next error", () => {
+		// Given: a DCS sequence closed by U+009C before another unhandled error.
+		const c1TerminatedDcs = [{
+			name: "api",
+			exitCode: 1,
+			durationMs: 20,
+			stdout: "",
+			stderr: [
+				"test/first.test.ts:",
+				"error: before boom\u001BPuntrusted DCS\u009C",
+				"      at <anonymous> (/repo/services/api/test/first.test.ts:5:24)",
+				"test/second.test.ts:",
+				"error: after boom",
+				"      at <anonymous> (/repo/services/api/test/second.test.ts:9:24)",
+				" 2 errors",
+			].join("\n"),
+		}] satisfies readonly TestSuiteResult[];
+
+		// When
+		const report = formatTestReport(c1TerminatedDcs);
+
+		// Then: the later diagnostic and tally survive the control sequence.
+		expect(report).toContain("error: after boom");
+		expect(report).toContain("2 errors");
+		expect(report).not.toContain("untrusted DCS");
 	});
 });

--- a/scripts/test-report.ts
+++ b/scripts/test-report.ts
@@ -6,56 +6,191 @@ export interface TestSuiteResult {
 	readonly stderr: string;
 }
 
-const ANSI_ESCAPE_PATTERN = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 const BUN_FAILURE_PATTERN = /^\(fail\)/;
 const BUN_TEST_FILE_PATTERN = /^\S.*\.test\.[cm]?[jt]sx?:$/;
+/**
+ * Header of a thrown value Bun printed: `error: boom` for an `Error` or a bare
+ * throw, `TypeError: …` / `WeirdError: …` for anything carrying its own `name`.
+ * Only trusted when the stack frame Bun prints underneath follows it — on its
+ * own the shape is common enough in ordinary log noise (`[update] … failed:
+ * disk I/O error`) to flag half a green run.
+ */
+const BUN_ERROR_HEADER_PATTERN = /^(?:error|[A-Za-z_$][\w$]*Error):\s/;
+const BUN_STACK_FRAME_PATTERN = /^\s+at\s/;
+/** Bun's own banner for a throw that landed while no test was running. */
+const BUN_UNATTRIBUTED_BANNER = "# Unhandled error between tests";
+/** A summary tally line: ` 1861 pass`, ` 0 fail`, ` 8 errors`. */
+const BUN_SUMMARY_PATTERN = /^\s*\d+\s+(?:pass|fail|skip|error)/;
 const MAX_FALLBACK_LINES = 120;
+const MAX_FALLBACK_CHARACTERS = 2_000;
+const MAX_SUMMARY_LINES = 20;
+const MAX_DIAGNOSTIC_SECTIONS = 8;
+const MAX_DIAGNOSTIC_CHARACTERS = 2_000;
+const MAX_SUMMARY_CHARACTERS = 4_000;
 
 function formatDuration(durationMs: number): string {
 	return durationMs < 1000 ? `${durationMs}ms` : `${(durationMs / 1000).toFixed(1)}s`;
 }
 
-function stripAnsi(value: string): string {
-	return value.replace(ANSI_ESCAPE_PATTERN, "");
+function stripTerminalControls(value: string): string {
+	const output: string[] = [];
+	for (let index = 0; index < value.length; index++) {
+		const code = value.charCodeAt(index);
+		const next = value[index + 1] ?? "";
+		const escapeString = code === 0x1B && (next === "]" || next === "P" || next === "X" || next === "^" || next === "_");
+		const c1String = code === 0x90 || code === 0x98 || code === 0x9D || code === 0x9E || code === 0x9F;
+		if (escapeString || c1String) {
+			const osc = next === "]" || code === 0x9D;
+			for (index += escapeString ? 2 : 1; index < value.length; index++) {
+					const sequenceCode = value.charCodeAt(index);
+					if (sequenceCode === 0x9C || (osc && sequenceCode === 0x07)) break;
+					if (sequenceCode === 0x1B && value[index + 1] === "\\") {
+						index++;
+						break;
+					}
+				}
+				continue;
+		}
+		if (code === 0x1B) {
+			if (next === "[") {
+				for (index += 2; index < value.length; index++) {
+					const sequenceCode = value.charCodeAt(index);
+					if (sequenceCode >= 0x40 && sequenceCode <= 0x7E) break;
+				}
+				continue;
+			}
+			if (next !== "") index++;
+			continue;
+		}
+		if (code <= 0x08 || (code >= 0x0B && code <= 0x1F) || (code >= 0x7F && code <= 0x9F)) continue;
+		output.push(value[index] ?? "");
+	}
+	return output.join("");
 }
 
 function lastLines(value: string): string {
-	return value.split("\n").slice(-MAX_FALLBACK_LINES).join("\n").trim();
+	return limitCharacters(value.split("\n").slice(-MAX_FALLBACK_LINES).join("\n").trim(), MAX_FALLBACK_CHARACTERS, "output");
+}
+
+function limitLines(lines: readonly string[], maximum: number, label: string): string {
+	if (lines.length <= maximum) return lines.join("\n").trim();
+	const leadingLines = Math.ceil(maximum / 2);
+	const trailingLines = maximum - leadingLines;
+	return [
+		...lines.slice(0, leadingLines),
+		`... ${label} truncated after ${maximum} lines`,
+		...lines.slice(-trailingLines),
+	].join("\n").trim();
+}
+
+function limitCharacters(value: string, maximum: number, label: string): string {
+	if (value.length <= maximum) return value;
+	const leadingCharacters = Math.ceil(maximum / 2);
+	const trailingCharacters = maximum - leadingCharacters;
+	return [
+		value.slice(0, leadingCharacters),
+		`... ${label} truncated after ${maximum} characters`,
+		value.slice(-trailingCharacters),
+	].join("\n");
+}
+
+/**
+ * Index of the first line of the trailing tally block, or -1. Found from the
+ * end: a tally line's shape (`<n> <word>`) is loose enough that scanning
+ * forwards can hit ordinary log output and cut the report off at it.
+ */
+function findSummaryStart(lines: readonly string[]): number {
+	let start = -1;
+	for (let index = lines.length - 1; index >= 0; index--) {
+		if (!BUN_SUMMARY_PATTERN.test(lines[index] ?? "")) {
+			if (start !== -1) break;
+			continue;
+		}
+		start = index;
+	}
+	return start;
+}
+
+/** Split Bun's output at its `path/to/file.test.ts:` headers, preamble first. */
+function splitTestFileSections(lines: readonly string[]): readonly (readonly string[])[] {
+	const sections: string[][] = [];
+	let current: string[] = [];
+	for (const line of lines) {
+		if (BUN_TEST_FILE_PATTERN.test(line) && current.length > 0) {
+			sections.push(current);
+			current = [];
+		}
+		current.push(line);
+	}
+	if (current.length > 0) sections.push(current);
+	return sections;
+}
+
+/**
+ * A section is worth reporting when it holds a failed test or a thrown value
+ * Bun could not attribute to one. The second case is why this is section-based
+ * rather than anchored on `(fail)`: a suite can exit non-zero on `0 fail` alone
+ * (`8 errors` — a timer or floating promise that threw between tests), and
+ * those blocks print where they happen, far from the tail.
+ */
+function isDiagnosticSection(lines: readonly string[]): boolean {
+	return lines.some((line, index) => (
+		BUN_FAILURE_PATTERN.test(line)
+		|| line.startsWith(BUN_UNATTRIBUTED_BANNER)
+		|| (BUN_ERROR_HEADER_PATTERN.test(line) && BUN_STACK_FRAME_PATTERN.test(lines[index + 1] ?? ""))
+	));
+}
+
+function formatBunSummary(lines: readonly string[], summaryStart: number): string {
+	return limitCharacters(
+		limitLines(lines.slice(summaryStart), MAX_SUMMARY_LINES, "summary output"),
+		MAX_SUMMARY_CHARACTERS,
+		"summary output",
+	);
+}
+
+function extractBunSummary(output: string): string | null {
+	const lines = output.split("\n");
+	const summaryStart = findSummaryStart(lines);
+	return summaryStart === -1 ? null : formatBunSummary(lines, summaryStart);
 }
 
 function extractBunFailure(stderr: string): string | null {
 	const lines = stderr.split("\n");
-	const failureIndexes = lines.flatMap((line, index) => BUN_FAILURE_PATTERN.test(line) ? [index] : []);
-	if (failureIndexes.length === 0) return null;
+	const summaryStart = findSummaryStart(lines);
+	const body = summaryStart === -1 ? lines : lines.slice(0, summaryStart);
 
-	const sections: string[] = [];
-	let previousFailureIndex = -1;
-	for (const failureIndex of failureIndexes) {
-		let start = previousFailureIndex + 1;
-		if (previousFailureIndex === -1) {
-			for (let index = failureIndex; index >= 0; index--) {
-				if (BUN_TEST_FILE_PATTERN.test(lines[index] ?? "")) {
-					start = index;
-					break;
-				}
-			}
-		}
-		sections.push(lines.slice(start, failureIndex + 1).join("\n").trim());
-		previousFailureIndex = failureIndex;
-	}
+	const diagnosticSections = splitTestFileSections(body)
+		.filter(isDiagnosticSection)
+		.filter((section) => section.some((line) => line.trim() !== ""));
+	if (diagnosticSections.length === 0) return null;
 
-	const summaryStart = lines.findIndex((line, index) => (
-		index > previousFailureIndex && /^\s*\d+\s+(?:pass|fail|skip)/.test(line)
+	const sections = diagnosticSections.slice(0, MAX_DIAGNOSTIC_SECTIONS).map((section) => limitCharacters(
+		limitLines(section, MAX_FALLBACK_LINES, "diagnostic output"),
+		MAX_DIAGNOSTIC_CHARACTERS,
+		"diagnostic output",
 	));
-	if (summaryStart !== -1) sections.push(lines.slice(summaryStart).join("\n").trim());
+	if (diagnosticSections.length > MAX_DIAGNOSTIC_SECTIONS) {
+		sections.push(`... ${diagnosticSections.length - MAX_DIAGNOSTIC_SECTIONS} additional diagnostic sections omitted`);
+	}
+	if (summaryStart !== -1) sections.push(formatBunSummary(lines, summaryStart));
 	return sections.filter((section) => section !== "").join("\n\n");
 }
 
 function formatFailure(result: TestSuiteResult): string {
-	const stdout = stripAnsi(result.stdout);
-	const stderr = stripAnsi(result.stderr);
-	const actionable = extractBunFailure(stderr);
-	if (actionable !== null) return `--- ${result.name} ---\n\n${actionable}`;
+	const stdout = stripTerminalControls(result.stdout);
+	const stderr = stripTerminalControls(result.stderr);
+	const stdoutActionable = extractBunFailure(stdout);
+	const stderrActionable = extractBunFailure(stderr);
+	const actionable = [
+		stdoutActionable,
+		stderrActionable,
+		stdoutActionable === null ? extractBunSummary(stdout) : null,
+		stderrActionable === null ? extractBunSummary(stderr) : null,
+	]
+		.filter((output): output is string => output !== null)
+		.join("\n\n");
+	if (actionable !== "") return `--- ${result.name} ---\n\n${actionable}`;
 
 	const output = [
 		stdout.trim() === "" ? "" : `[stdout]\n${lastLines(stdout)}`,


### PR DESCRIPTION
## Summary

- retain actionable Bun assertion and uncaught-error diagnostics from both output streams
- preserve summaries while filtering unrelated runner noise
- bound report excerpts and sanitize ANSI/C1 terminal-control sequences

## Validation

- bun test scripts/test-report.test.ts
- bun run check
- bun run build
- independent goal, QA, code-quality, security, and integration gates