### PR TITLE
fix(web): make the memory message-range slider usable in Firefox

### DIFF
--- a/apps/web/src/components/context/DualRangeSlider.test.tsx
+++ b/apps/web/src/components/context/DualRangeSlider.test.tsx
@@ -1,5 +1,5 @@
 /**
- * DualRangeSlider — from/to invariant (characterization).
+ * DualRangeSlider — from/to invariant + wrapper-driven pointer interaction.
  *
  * The slider exposes two overlapping range inputs (`dual-range-l` = lower/from,
  * `dual-range-u` = upper/to). The invariant: dragging `from` up never crosses
@@ -7,8 +7,18 @@
  * Pinned because a sign-flip or swapped safeFrom/safeTo would silently break
  * selection.
  *
- * Plain <input type="range"> (no Radix), so happy-dom's 0x0 layout is fine —
- * unlike the Radix-Popover DropdownSelect keyboard test, which is skipped.
+ * The pointer suite pins the Firefox fix: dragging must be driven by the
+ * WRAPPER, never by per-thumb hit-testing. Making each thumb its own hit target
+ * needs `::-webkit-slider-thumb{pointer-events:auto}` under a
+ * `pointer-events:none` host — Firefox ignores that on `::-moz-range-thumb`, so
+ * the whole control went dead there. These tests dispatch on the wrapper and
+ * never touch an input, which is exactly what a browser without thumb
+ * hit-testing does.
+ *
+ * Plain <input type="range"> (no Radix), so happy-dom's 0x0 layout is fine for
+ * the invariant suite — unlike the Radix-Popover DropdownSelect keyboard test,
+ * which is skipped. The pointer suite stubs the wrapper's box, since happy-dom
+ * has no layout of its own.
  */
 import { beforeAll, describe, expect, it, mock } from "bun:test";
 import { useDomEnv } from "../../../test/dom-env.js";
@@ -68,11 +78,64 @@ describe("DualRangeSlider — from/to invariant", () => {
 	});
 
 	it("min === max (degenerate single-message range) renders without throwing and pins both thumbs", () => {
-		// Guards the trackPct divide-by-zero (max > min ? … : 0). Value is already
+		// Guards the ratio divide-by-zero (max > min ? … : 0). Value is already
 		// at the only legal bound, so React does not fire onChange for a no-op
 		// change — assert the render + bound value instead.
 		const { lower, upper } = setup({ from: 1, to: 1, min: 1, max: 1 });
 		expect(lower.value).toBe("1");
 		expect(upper.value).toBe("1");
+	});
+});
+
+/**
+ * 216px box − 16px thumb = 200px of travel across min..max = 1..101, i.e. one
+ * message every 2px. Thumb centre for value v sits at `8 + (v - 1) * 2`, so
+ * clientX 88 → 41 and clientX 148 → 71.
+ */
+const TRACK_WIDTH = 216;
+
+function setupPointer(props: { from: number; to: number; disabled?: boolean }) {
+	const onChange = mock();
+	const { container } = render(
+		<DualRangeSlider
+			min={1}
+			max={101}
+			from={props.from}
+			to={props.to}
+			disabled={props.disabled}
+			onChange={onChange}
+		/>,
+	);
+	const track = container.querySelector(".dual-range-l")?.parentElement;
+	if (!track) throw new Error("wrapper not found");
+	// happy-dom has no layout engine, so the wrapper measures 0x0 and every
+	// pointer position would clamp to `min`. Stub the box the component reads.
+	track.getBoundingClientRect = () => new DOMRect(0, 0, TRACK_WIDTH, 20);
+	return { onChange, track };
+}
+
+describe("DualRangeSlider — wrapper-driven pointer interaction", () => {
+	it("pointerdown near the lower thumb drags `from`, not the topmost input", () => {
+		// `dual-range-u` is the z-3 input covering the whole track. If the wrapper
+		// did not pick the handle itself, this press would move `to`.
+		const { onChange, track } = setupPointer({ from: 21, to: 81 });
+		fireEvent.pointerDown(track, { clientX: 88, button: 0, pointerId: 1 });
+		expect(onChange).toHaveBeenCalledWith(41, 81);
+	});
+
+	it("pointerdown near the upper thumb drags `to`", () => {
+		const { onChange, track } = setupPointer({ from: 21, to: 81 });
+		fireEvent.pointerDown(track, { clientX: 148, button: 0, pointerId: 1 });
+		expect(onChange).toHaveBeenCalledWith(21, 71);
+	});
+
+	it("ignores the pointer while disabled", () => {
+		// The old shape got this from the inputs' `disabled` attribute; a
+		// wrapper-driven press has to re-check it or the range stays draggable
+		// mid-generation.
+		const { onChange, track } = setupPointer({ from: 21, to: 81, disabled: true });
+		fireEvent.pointerDown(track, { clientX: 88, button: 0, pointerId: 1 });
+		fireEvent.pointerMove(track, { clientX: 148, pointerId: 1 });
+		expect(onChange).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/components/context/DualRangeSlider.tsx
+++ b/apps/web/src/components/context/DualRangeSlider.tsx
@@ -1,4 +1,11 @@
+import { useRef, useState } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 import { cn } from "../../lib/cn.js";
+
+/** Thumb diameter — must stay in sync with `.dual-range::-*-thumb` in styles.css. */
+const THUMB_PX = 16;
+
+type Handle = "from" | "to";
 
 /**
  * Dual-range slider — memory-strategy primitive for the Summary tab.
@@ -7,56 +14,119 @@ import { cn } from "../../lib/cn.js";
  * upper/to). Invariant: dragging `from` up never crosses `to`, dragging `to`
  * down never crosses `from`; both clamp to [min,max]. Pinned by
  * DualRangeSlider.test.tsx.
+ *
+ * The inputs are inert to the pointer (`.dual-range` sets `pointer-events:none`)
+ * and remain for keyboard control and assistive tech; the wrapper hit-tests the
+ * pointer, picks the nearer handle, and drives the value itself. Letting each
+ * thumb be its own hit target instead — the shape this component used to have —
+ * only works in Chromium, because Firefox ignores `pointer-events` on
+ * `::-moz-range-thumb`; see the `.dual-range` comment in styles.css.
  */
 export function DualRangeSlider({ min, max, from, to, disabled, onChange }: {
   min: number; max: number; from: number; to: number;
   disabled?: boolean;
   onChange: (from: number, to: number) => void;
 }) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const fromRef = useRef<HTMLInputElement>(null);
+  const toRef = useRef<HTMLInputElement>(null);
+  const draggingRef = useRef<Handle | null>(null);
+  const [hot, setHot] = useState<Handle | null>(null);
+
   const clampValue = (v: number) => Math.min(max, Math.max(min, Number.isFinite(v) ? v : min));
   const safeFrom = Math.min(clampValue(from), clampValue(to));
   const safeTo = Math.max(clampValue(from), clampValue(to));
 
-  function handleFrom(v: number) {
+  /** Applies the from/to invariant and skips no-op emissions during a drag. */
+  function commit(handle: Handle, v: number) {
     const next = clampValue(v);
-    onChange(Math.min(next, safeTo), safeTo);
+    const nextFrom = handle === "from" ? Math.min(next, safeTo) : safeFrom;
+    const nextTo = handle === "from" ? safeTo : Math.max(safeFrom, next);
+    if (nextFrom === safeFrom && nextTo === safeTo) return;
+    onChange(nextFrom, nextTo);
   }
-  function handleTo(v: number) {
-    const next = clampValue(v);
-    onChange(safeFrom, Math.max(safeFrom, next));
-  }
-  const trackPct = (v: number) => max > min ? Math.min(100, Math.max(0, ((clampValue(v) - min) / (max - min)) * 100)) : 0;
 
-  const thumbCls =
-    "absolute inset-x-0 top-0 h-5 w-full appearance-none bg-transparent " +
-    "[&::-webkit-slider-thumb]:h-[16px] [&::-webkit-slider-thumb]:w-[16px] " +
-    "[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full " +
-    "[&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-accent " +
-    "[&::-webkit-slider-thumb]:bg-surface [&::-webkit-slider-thumb]:shadow-sm " +
-    "[&::-webkit-slider-thumb]:transition-shadow [&::-webkit-slider-thumb]:hover:shadow-[0_0_0_3px_var(--accent-dim)] " +
-    "[&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:cursor-pointer";
+  // A native thumb travels between its own half-widths, so the painted fill and
+  // the pointer math use that same inset — otherwise grabbing a thumb near an
+  // end would snap it by up to half a thumb.
+  const ratio = (v: number) => max > min ? (clampValue(v) - min) / (max - min) : 0;
+  const offset = (r: number) => `calc(${(r * 100).toFixed(3)}% + ${(THUMB_PX / 2 - r * THUMB_PX).toFixed(3)}px)`;
+  const fillSpan = (r: number) => `calc(${(r * 100).toFixed(3)}% - ${(r * THUMB_PX).toFixed(3)}px)`;
+
+  function valueAt(clientX: number) {
+    const el = trackRef.current;
+    if (!el || max <= min) return min;
+    const rect = el.getBoundingClientRect();
+    const travel = rect.width - THUMB_PX;
+    if (travel <= 0) return min;
+    return clampValue(Math.round(min + ((clientX - rect.left - THUMB_PX / 2) / travel) * (max - min)));
+  }
+
+  /** Nearer handle wins; when both thumbs are stacked, the one that can still move. */
+  function nearestHandle(v: number): Handle {
+    const dFrom = Math.abs(v - safeFrom);
+    const dTo = Math.abs(v - safeTo);
+    if (dFrom < dTo) return "from";
+    if (dTo < dFrom) return "to";
+    return v > safeFrom ? "to" : "from";
+  }
+
+  function onPointerDown(e: ReactPointerEvent<HTMLDivElement>) {
+    if (disabled || e.button !== 0) return;
+    const v = valueAt(e.clientX);
+    const handle = nearestHandle(v);
+    draggingRef.current = handle;
+    setHot(handle);
+    e.currentTarget.setPointerCapture(e.pointerId);
+    (handle === "from" ? fromRef : toRef).current?.focus({ preventScroll: true });
+    commit(handle, v);
+  }
+
+  function onPointerMove(e: ReactPointerEvent<HTMLDivElement>) {
+    if (disabled) return;
+    const v = valueAt(e.clientX);
+    const dragging = draggingRef.current;
+    if (dragging) commit(dragging, v);
+    else setHot(nearestHandle(v));
+  }
+
+  function endDrag(e: ReactPointerEvent<HTMLDivElement>) {
+    draggingRef.current = null;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) e.currentTarget.releasePointerCapture(e.pointerId);
+  }
+
+  const inputCls = "absolute inset-x-0 top-0 h-5 w-full dual-range";
 
   return (
-    <div className="relative h-5 pb-4">
+    <div
+      ref={trackRef}
+      className={cn("relative h-5 touch-pan-y pb-4", !disabled && "cursor-pointer")}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onPointerLeave={() => { if (!draggingRef.current) setHot(null); }}
+    >
       {/* Track bg */}
       <div className="absolute left-0 right-0 top-[7px] h-[6px] rounded-full bg-s3" />
       {/* Filled track between the two thumbs */}
       <div
         className="absolute top-[7px] h-[6px] rounded-full bg-accent"
-        style={{ left: `${trackPct(safeFrom)}%`, width: `${Math.max(0, trackPct(safeTo) - trackPct(safeFrom))}%` }}
+        style={{ left: offset(ratio(safeFrom)), width: fillSpan(Math.max(0, ratio(safeTo) - ratio(safeFrom))) }}
       />
-      {/* Both inputs: pointer-events:none on container, auto on thumb via Tailwind */}
       <input
+        ref={fromRef}
         type="range" min={min} max={max} value={safeFrom}
         disabled={disabled}
-        onChange={(e) => handleFrom(Number(e.target.value))}
-        className={cn("dual-range-l z-[2] pointer-events-none", thumbCls)}
+        onChange={(e) => commit("from", Number(e.target.value))}
+        className={cn("dual-range-l z-[2]", inputCls, hot === "from" && "is-hot")}
       />
       <input
+        ref={toRef}
         type="range" min={min} max={max} value={safeTo}
         disabled={disabled}
-        onChange={(e) => handleTo(Number(e.target.value))}
-        className={cn("dual-range-u z-[3] pointer-events-none", thumbCls)}
+        onChange={(e) => commit("to", Number(e.target.value))}
+        className={cn("dual-range-u z-[3]", inputCls, hot === "to" && "is-hot")}
       />
     </div>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -360,6 +360,20 @@ html,body{height:100%;background:var(--page-bg, var(--bg));color:var(--t1);overf
 .crop-zoom-slider::-webkit-slider-thumb:hover{transform:scale(1.15)}
 .crop-zoom-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;background:var(--accent);border:2px solid var(--surface);box-shadow:0 1px 4px rgba(0,0,0,.25);cursor:pointer}
 
+/* ── Summary message-range dual slider (DualRangeSlider) ──
+   Two full-width range inputs stacked on one track. Making each *thumb* its own
+   hit target — host `pointer-events:none` + `::-webkit-slider-thumb{pointer-events:auto}`
+   — is Chromium-only: Firefox computes `pointer-events` on `::-moz-range-thumb`
+   but ignores it while hit-testing, so the whole control was dead there. Both
+   inputs are therefore inert to the pointer everywhere and the component drives
+   the values from its wrapper; these rules only paint the thumb. `.is-hot` marks
+   the handle the pointer would grab, replacing the old thumb `:hover`. */
+.dual-range{-webkit-appearance:none;appearance:none;background:transparent;pointer-events:none;margin:0}
+.dual-range::-webkit-slider-thumb{-webkit-appearance:none;width:16px;height:16px;border-radius:50%;background:var(--surface);border:2px solid var(--accent);box-shadow:0 1px 3px 0 rgb(0 0 0/.1),0 1px 2px -1px rgb(0 0 0/.1);transition:box-shadow .15s}
+.dual-range::-moz-range-thumb{width:16px;height:16px;border-radius:50%;background:var(--surface);border:2px solid var(--accent);box-shadow:0 1px 3px 0 rgb(0 0 0/.1),0 1px 2px -1px rgb(0 0 0/.1);transition:box-shadow .15s}
+.dual-range.is-hot::-webkit-slider-thumb{box-shadow:0 0 0 3px var(--accent-dim)}
+.dual-range.is-hot::-moz-range-thumb{box-shadow:0 0 0 3px var(--accent-dim)}
+
 /* ── Avatar crop: keep preview sharp when zoomed ──
    react-easy-crop shrinks the <img> to fit (max-width/height:100%) then zooms
    via transform: scale(). Its own stylesheet sets will-change: transform,


### PR DESCRIPTION
## Bug

In the Memory modal, the **Message range** slider was unstyled and completely unclickable in Firefox. Chromium was fine.

## Root cause

`DualRangeSlider` made each thumb its own hit target: `pointer-events:none` on the two stacked full-width `<input type=range>` hosts, plus `pointer-events:auto` on `::-webkit-slider-thumb`. That is the only way to reach the lower thumb when both inputs span the whole track — and it is Chromium-only.

Firefox has no `::-webkit-slider-thumb` at all, hence the default white thumbs. And while it *does* compute `pointer-events` on `::-moz-range-thumb`, it ignores the property when hit-testing, so the host's `none` won and the whole control was dead. Measured on a minimal repro:

```
FIREFOX, current production shape:
  hostPointerEvents:  "none"
  thumbPointerEvents: "auto"    <- the declaration is accepted
  thumbWidth:         "16px"    <- styling does apply
  click on track:     20 -> 20  <- but hit-testing ignores it

same repro with pointer-events:auto on the host:
  click on track:     20 -> 76
```

Dropping `none` from the host is not an option: the top input (`z-3`, `to`) would swallow every click and `from` would become unreachable, in both browsers.

## Fix

- `styles.css` grows a `.dual-range` block mirroring every thumb rule for `::-moz-range-thumb`, with `.is-hot` replacing the old pseudo-element `:hover`.
- Pointer interaction moves onto the wrapper: it measures the press, picks the nearer handle, and drives the value. The inputs stay for keyboard control and assistive tech.
- Pointer math and the painted fill now inset by half a thumb, matching where a native thumb actually sits, so grabbing a handle near either end no longer snaps it.

### Why not the smaller fix

Swapping host `pointer-events` between the two inputs by pointer proximity is ~15 lines and works with a mouse. But the browser resolves the hit target at touchstart, before the swap lands:

```
FIREFOX  tap@25% (nearest thumb is `lo`): ["pointerover:lo", "down@hi"] -> hi moved
CHROMIUM tap@25% (nearest thumb is `lo`): ["pointerover:lo", "down@hi"] -> hi moved
```

Chromium handles touch correctly today, so that regression was not worth the smaller diff.

## Verification

Real Firefox and Chromium via Playwright against the live app, chat `QA · 1000 messages`:

| | Firefox | Chromium |
|---|---|---|
| `::-moz-range-thumb` computed | 16×16, border 2px accent, radius 50% | n/a |
| drag lower thumb, left edge → 40% | `from: 1 → 396` | `1 → 397` |
| drag upper thumb, right edge → 70% | `to: 999 → 704` | `999 → 705` |

Screenshots of the two browsers are pixel-identical; the 1-message delta is rounding on the mouse-release point.

`bun run typecheck` clean (type-gate included). `bun run test` — 8/8 suites pass. The two new pointer tests fail against the old component and pass against the new one (verified via stash).

## Behaviour change

Clicking the track now moves the nearest handle — native slider behaviour. A Chromium track click previously did nothing; that was a side effect of the thumb-only hit target, not a decision. Easy to restrict back to thumb-radius grabbing if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)