### PR TITLE
perf(web): stop re-tokenizing the chat on every memory-slider step

### DIFF
--- a/apps/web/src/components/context/SummaryTab.tsx
+++ b/apps/web/src/components/context/SummaryTab.tsx
@@ -14,7 +14,8 @@ import { useIsMobile } from "../../hooks/use-mobile.js";
 import { cn } from "../../lib/cn.js";
 import { useT } from "../../i18n/context.js";
 import { DualRangeSlider } from "./DualRangeSlider.js";
-import { computeTokenEstimate, TokenEstimate } from "./TokenEstimate.js";
+import { computeTokenEstimate, TokenEstimate, type CountedMessage } from "./TokenEstimate.js";
+import { countTokens } from "../../utils/tokenizer.js";
 import { useSnapshotStore } from "../../stores/snapshot-store.js";
 import {
   createChatSummaryAction,
@@ -161,12 +162,22 @@ export function useSummaryTab({
   const effectiveModel = (useChatModel ? (pinnedModel ?? activeProvider?.defaultModel ?? selectedModel) : (pinnedModel ?? selectedModel))?.trim() ?? "";
 
   /* ─── derived data ─── */
+  // Tokenizing the chat is the expensive part of the estimate — a 1000-message
+  // branch costs ~150ms per pass. Both memory sliders recompute the estimate on
+  // every step, so counting has to be keyed on the message set (which cannot
+  // change while a thumb is held) rather than on the slider values. Dragging
+  // then only re-sums integers.
+  const countedMessages = useMemo<CountedMessage[]>(
+    () => messages.map((m) => ({ position: m.position, tokens: countTokens(m.content) })),
+    [messages],
+  );
+
   const selectedRangeMessages = useMemo(() => {
-    return messages.filter((m) => {
+    return countedMessages.filter((m) => {
       const pos = (m.position ?? 0) + 1;
       return pos >= rangeFrom && pos <= rangeTo;
     });
-  }, [messages, rangeFrom, rangeTo]);
+  }, [countedMessages, rangeFrom, rangeTo]);
 
   const excludedRanges = useMemo(() => {
     return summaries
@@ -174,9 +185,12 @@ export function useSummaryTab({
       .map((s) => ({ from: s.summarizedFrom, to: s.summarizedTo }));
   }, [summaries]);
 
+  // Keyed on the draft alone, so a slider step does not re-encode the summary.
+  const summaryTokens = useMemo(() => countTokens(draftText), [draftText]);
+
   const tokenEstimate = useMemo(
-    () => computeTokenEstimate(draftText, excludedRanges, historyLimit, messages, selectedRangeMessages),
-    [draftText, excludedRanges, historyLimit, messages, selectedRangeMessages],
+    () => computeTokenEstimate(summaryTokens, excludedRanges, historyLimit, countedMessages, selectedRangeMessages),
+    [summaryTokens, excludedRanges, historyLimit, countedMessages, selectedRangeMessages],
   );
 
   const contextPct = contextWindow.limit > 0 ? Math.min(100, Math.round((contextWindow.used / contextWindow.limit) * 100)) : 0;

--- a/apps/web/src/components/context/TokenEstimate.test.ts
+++ b/apps/web/src/components/context/TokenEstimate.test.ts
@@ -6,20 +6,25 @@
  * limit (historyLimit 0 = no limit); saved/pct floor at 0 with no
  * divide-by-zero on an empty selected range; no negative savings when the
  * summary exceeds the range.
+ *
+ * Token counts are supplied by the caller (SummaryTab counts once per message
+ * set so slider drags stay cheap), so the fixtures below run the real
+ * tokenizer themselves — the arithmetic stays pinned against genuine cl100k
+ * counts rather than invented integers.
  */
 import { describe, expect, test } from "bun:test";
 import { computeTokenEstimate } from "./TokenEstimate.js";
 import { countTokens } from "../../utils/tokenizer.js";
 
 describe("computeTokenEstimate — savings arithmetic", () => {
-	const msg = (position: number, content: string) => ({ position, content });
 	const tokens = (s: string) => countTokens(s);
+	const msg = (position: number, content: string) => ({ position, tokens: tokens(content) });
 
 	test("summary + history tokens add to total; savings computed from selected range", () => {
 		const draft = "A compact summary.";
 		const messages = [msg(0, "hello world"), msg(1, "another message here"), msg(2, "third one")];
 		const selected = [messages[0], messages[1]];
-		const out = computeTokenEstimate(draft, [], 100, messages, selected);
+		const out = computeTokenEstimate(tokens(draft), [], 100, messages, selected);
 		expect(out.summaryTokens).toBe(tokens(draft));
 		expect(out.historyTokens).toBe(tokens("hello world") + tokens("another message here") + tokens("third one"));
 		expect(out.total).toBe(out.summaryTokens + out.historyTokens);
@@ -36,25 +41,25 @@ describe("computeTokenEstimate — savings arithmetic", () => {
 		const messages = [
 			msg(0, "aaaa"), msg(1, "bbbb"), msg(2, "excluded one"), msg(3, "excluded two"), msg(4, "eeee"),
 		];
-		const out = computeTokenEstimate("", [{ from: 3, to: 4 }], 2, messages, []);
+		const out = computeTokenEstimate(0, [{ from: 3, to: 4 }], 2, messages, []);
 		expect(out.historyTokens).toBe(tokens("bbbb") + tokens("eeee"));
 	});
 
 	test("historyLimit 0 means ‘no limit’ — all non-excluded messages count", () => {
 		const messages = [msg(0, "a"), msg(1, "b"), msg(2, "c")];
-		const out = computeTokenEstimate("", [], 0, messages, []);
+		const out = computeTokenEstimate(0, [], 0, messages, []);
 		expect(out.historyTokens).toBe(tokens("a") + tokens("b") + tokens("c"));
 	});
 
 	test("selectedRawTokens 0 → saved 0, pct 0 (no divide-by-zero)", () => {
-		const out = computeTokenEstimate("summary", [], 10, [msg(0, "x")], []);
+		const out = computeTokenEstimate(tokens("summary"), [], 10, [msg(0, "x")], []);
 		expect(out.selectedRawTokens).toBe(0);
 		expect(out.saved).toBe(0);
 		expect(out.pct).toBe(0);
 	});
 
 	test("summary longer than the selected range → saved floored at 0 (no negative savings)", () => {
-		const out = computeTokenEstimate("x".repeat(2000), [], 10, [], [{ content: "short" }]);
+		const out = computeTokenEstimate(tokens("x".repeat(2000)), [], 10, [], [{ tokens: tokens("short") }]);
 		expect(out.saved).toBe(0);
 		expect(out.pct).toBe(0);
 	});

--- a/apps/web/src/components/context/TokenEstimate.tsx
+++ b/apps/web/src/components/context/TokenEstimate.tsx
@@ -1,29 +1,37 @@
 import { useT } from "../../i18n/context.js";
-import { countTokens } from "../../utils/tokenizer.js";
+
+/** A message reduced to what the estimate needs: its slot and its token cost. */
+export interface CountedMessage {
+  position?: number | null;
+  tokens: number;
+}
 
 /**
  * Compute the token-savings estimate for the Summary memory strategy. Pure
- * (mirrors the original `useMemo` body in ContextMemoryModal) so the
  * arithmetic — history excludes summarized ranges then slices to the limit;
- * `saved`/`pct` derive from the selected-range raw tokens minus the summary —
- * is unit-testable without rendering the modal.
+ * `saved`/`pct` derive from the selected-range raw tokens minus the summary.
+ *
+ * Counting is deliberately the caller's job. Both memory sliders re-run this on
+ * every step, and BPE-encoding a 1000-message chat costs ~150ms per pass, which
+ * is what made dragging either thumb crawl. Message content cannot change while
+ * a thumb is held, so SummaryTab counts once per message set and this function
+ * only ever sums integers.
  */
 export function computeTokenEstimate(
-  draftText: string,
+  summaryTokens: number,
   excludedRanges: ReadonlyArray<{ from: number; to: number }>,
   historyLimit: number,
-  messages: ReadonlyArray<{ position?: number | null; content: string }>,
-  selectedRangeMessages: ReadonlyArray<{ content: string }>,
+  messages: ReadonlyArray<CountedMessage>,
+  selectedRangeMessages: ReadonlyArray<{ tokens: number }>,
 ): { summaryTokens: number; historyTokens: number; total: number; selectedRawTokens: number; saved: number; pct: number } {
-  const summaryTokens = countTokens(draftText);
   const limitedMessages = messages
     .filter((m) => {
       const pos = (m.position ?? 0) + 1;
       return !excludedRanges.some((r) => pos >= r.from && pos <= r.to);
     })
     .slice(-(historyLimit || messages.length));
-  const historyTokens = limitedMessages.reduce((sum, m) => sum + countTokens(m.content), 0);
-  const selectedRawTokens = selectedRangeMessages.reduce((sum, m) => sum + countTokens(m.content), 0);
+  const historyTokens = limitedMessages.reduce((sum, m) => sum + m.tokens, 0);
+  const selectedRawTokens = selectedRangeMessages.reduce((sum, m) => sum + m.tokens, 0);
   const saved = Math.max(0, selectedRawTokens - summaryTokens);
   const pct = selectedRawTokens > 0 ? Math.round((saved / selectedRawTokens) * 100) : 0;
   return { summaryTokens, historyTokens, total: summaryTokens + historyTokens, selectedRawTokens, saved, pct };


### PR DESCRIPTION
## Problem

On a long chat (the 1000-message QA fixture), dragging either **Message range** thumb or the **Messages in prompt** slider crawls.

## Root cause

Not a guess — a CPU profile of 20 slider steps, sampled at 100µs:

```
self%   self-ms  function
 28.4%     980   bytePairMerge      (js-tiktoken)
 19.7%     680   encode             (js-tiktoken)
 14.8%     512   encode             (js-tiktoken)
 12.6%     435   (garbage collector)
  9.5%     329   jsxDEV             (React dev-mode)
  4.2%     144   escapeRegex        (js-tiktoken)
```

~70% of samples are js-tiktoken BPE, plus 12.6% GC for the token arrays it allocates. React rendering is ~10%, and that is dev-mode JSX which production does not build.

`computeTokenEstimate` called `countTokens(m.content)` once per message for the history sum and again for the selected range — up to **2000 BPE encodes per slider step**. Message content cannot change while a thumb is held, so every one of those encodes repeated work already done.

Two sums also shared one `useMemo`, so a range step recomputed `historyTokens` (which does not depend on the range) and a history step recomputed `selectedRawTokens`.

## Fix

Counting moves to the caller. `SummaryTab` derives per-message token counts in a memo keyed on the message set, and the draft's count in a memo keyed on the draft; `computeTokenEstimate` only sums integers. Dragging re-runs the arithmetic, never the tokenizer.

This is preferred over "recompute on release": the estimate stays live while dragging, which is the point of the readout.

## Measurements

Production build, 40 steps per slider, same machine and fixture:

| | before | after | |
|---|---|---|---|
| Message range | 66.7ms/step (max 89.1) | **2.0ms/step** (max 9.8) | 33× |
| Messages in prompt | 53.3ms/step (max 78.9) | **1.5ms/step** (max 1.8) | 36× |

Both now sit far inside a 16ms frame budget, with headroom for slower machines.

A post-fix profile shows the tokenizer gone from the hot path entirely — what remains is `jsxDEV`, `logComponentRender`, `validateProperty`: React development-mode instrumentation absent from production.

## Tests

`computeTokenEstimate`'s suite keeps the same boundary (the savings arithmetic) and still runs the real tokenizer to build its fixtures, so the counts it pins are genuine cl100k values rather than invented integers.

`bun run typecheck` clean (type-gate included), `bun run test` 8/8 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)