### PR TITLE
feat(ci): build arm64 Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ concurrency:
 #     declared in scripts/test.ts (`skipOnWindows`) and in the two
 #     `skipIf(process.platform === "win32")` gates in scripts/*.test.ts —
 #     not here, so a dev running `bun run test` locally sees the same thing CI does.
-#   - The 4 platform builds fan out after typecheck passes.
+#   - The platform builds fan out after typecheck passes.
 # Nothing is published; the docker job only loads locally to prove the image builds.
 # Build artifacts are intentionally NOT uploaded — CI verifies compilation only,
 # not distribution. release.yml re-builds from the tag when cutting a real release;
@@ -214,15 +214,37 @@ jobs:
   build-docker:
     needs: [typecheck]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+          - platform: linux/arm64
+            arch: arm64
     steps:
       - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v4
+        if: matrix.arch == 'arm64'
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@v3
       # NOTE: NO docker/login-action — we don't push. Only verify the image builds.
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           push: false
           load: true
-          tags: vibe-tavern:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: vibe-tavern:ci-${{ matrix.arch }}
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-${{ matrix.arch }}
+      - name: Verify image architecture
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          ACTUAL_ARCH=$(docker image inspect \
+            --format '{{.Architecture}}' \
+            "vibe-tavern:ci-${EXPECTED_ARCH}")
+          test "$ACTUAL_ARCH" = "$EXPECTED_ARCH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ needs.version.outputs.sha }}
+      - uses: docker/setup-qemu-action@v4
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@v3
       - name: Set lowercase image name (GHCR requires lowercase)
         run: echo "IMAGE_NAME=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
@@ -337,10 +340,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
+          cache-from: |
+            type=gha
+            type=gha,scope=docker-amd64
+            type=gha,scope=docker-arm64
           cache-to: type=gha,mode=max
       - uses: actions/attest-build-provenance@v2
         with:


### PR DESCRIPTION
## Summary

- publish Docker releases as a multi-platform linux/amd64 and linux/arm64 manifest
- build both architectures in the CI Docker matrix
- verify each CI image reports the expected architecture
- isolate GitHub Actions caches by CI architecture

## Verification

- `actionlint`
- `git diff --check`
- local Buildx build and load for linux/amd64
- local Buildx build and load for linux/arm64 through QEMU
- Docker image metadata verified as linux/amd64 and linux/arm64
