### PR TITLE
fix(web): freeze overlay portal containers per open session (SHEET_PORTAL_SELF_TARGETING)

### DIFF
--- a/apps/web/src/components/layout/Rail.tsx
+++ b/apps/web/src/components/layout/Rail.tsx
@@ -11,7 +11,7 @@ import { TagFilterSheet } from "./rail/TagFilterSheet.js";
 import { RailCollapsedStrip } from "./rail/RailCollapsedStrip.js";
 import { CharacterChatsSheet } from "./rail/CharacterChatsSheet.js";
 import { Drawer } from "@base-ui/react/drawer";
-import { getModalPortal } from "../shared/modal-helpers.js";
+import { getApplicationModalPortal } from "../shared/modal-helpers.js";
 import { useSidebarChats } from "./hooks/use-sidebar-chats.js";
 import { useSidebarCharacters } from "./hooks/use-sidebar-characters.js";
 import { useRowActions } from "./hooks/use-row-actions.js";
@@ -237,7 +237,10 @@ export function Rail({ hidden }: { hidden?: boolean }) {
       )}
 
       {/* ═══ EXPANDED OVERLAY PANEL ═══ */}
-      <Drawer.Portal container={getModalPortal() ?? document.body}>
+      {/* App-level host, NOT the overlay stack: the rail must never chase the
+       *  topmost sheet anchor — a stack-top change mid-session would re-target
+       *  this portal and tear the rail down (SHEET_PORTAL_SELF_TARGETING). */}
+      <Drawer.Portal container={getApplicationModalPortal() ?? document.body}>
         <Drawer.Backdrop className="rail-backdrop fixed inset-0 z-[299] bg-black/40 backdrop-blur-sm" />
         <Drawer.Viewport className="fixed inset-0 z-[300]">
           <Drawer.Popup className="rail-popup glass-blur fixed left-0 top-0 bottom-0 flex w-[260px] flex-col border-r border-border bg-glass-bg shadow-theme-xl">

--- a/apps/web/src/components/shared/BottomSheet.test.tsx
+++ b/apps/web/src/components/shared/BottomSheet.test.tsx
@@ -45,12 +45,13 @@ let fireEvent: typeof import("@testing-library/react").fireEvent;
 let BottomSheet: typeof import("./BottomSheet.js").BottomSheet;
 let getModalPortal: typeof import("./modal-helpers.js").getModalPortal;
 let getTopmostOverlayPortal: typeof import("./modal-helpers.js").getTopmostOverlayPortal;
+let getApplicationModalPortal: typeof import("./modal-helpers.js").getApplicationModalPortal;
 let registerOverlayPortal: typeof import("./modal-helpers.js").registerOverlayPortal;
 
 beforeAll(async () => {
 	({ render, fireEvent } = await import("@testing-library/react"));
 	({ BottomSheet } = await import("./BottomSheet.js"));
-	({ getModalPortal, getTopmostOverlayPortal, registerOverlayPortal } = await import("./modal-helpers.js"));
+	({ getModalPortal, getTopmostOverlayPortal, getApplicationModalPortal, registerOverlayPortal } = await import("./modal-helpers.js"));
 });
 
 /** Scrim overlay — `.inset-0` (full-screen fixed) is unique to the scrim; the
@@ -187,15 +188,146 @@ describe("BottomSheet overlay portal (D2 — nested floating UI)", () => {
 	});
 
 	it("overlay stack is LIFO with clean unregister", () => {
+		// Nodes must be live (connected): the hardened resolver skips and prunes
+		// detached entries (SHEET_PORTAL_SELF_TARGETING), which is pinned in the
+		// resolver-hardening block below — this test pins ordering + unregister.
 		const a = document.createElement("div");
 		const b = document.createElement("div");
+		document.body.appendChild(a);
+		document.body.appendChild(b);
 		const unA = registerOverlayPortal(a);
 		const unB = registerOverlayPortal(b);
-		expect(getTopmostOverlayPortal()).toBe(b);
-		unA();
-		expect(getTopmostOverlayPortal()).toBe(b);
-		unB();
+		try {
+			expect(getTopmostOverlayPortal()).toBe(b);
+			unA();
+			expect(getTopmostOverlayPortal()).toBe(b);
+			unB();
+			expect(getTopmostOverlayPortal()).toBeNull();
+		} finally {
+			a.remove();
+			b.remove();
+		}
+	});
+});
+
+describe("BottomSheet portal session (SHEET_PORTAL_SELF_TARGETING)", () => {
+	// v1.2.2 regression: D2 made `getModalPortal()` consult the live overlay
+	// stack while `Drawer.Portal container={getModalPortal() ?? document.body}`
+	// re-evaluated it on EVERY render. The first open render portaled to body;
+	// once the sheet's own anchor registered (at commit), the NEXT re-render
+	// resolved the container to the sheet's OWN anchor — a node inside the very
+	// subtree being re-targeted — so React tore the sheet down mid-life: the
+	// dialog DOM vanished while `open` stayed true (re-tap = no-op), Base UI's
+	// inert restore never landed (`#root[data-base-ui-inert]` leak → whole app
+	// dead to pointer input), onOpenChange never fired. These tests pin the
+	// session contract: the container is captured once per open transition and
+	// frozen for the whole open lifecycle.
+	function portalNode(): HTMLElement {
+		const el = document.querySelector<HTMLElement>('[data-overlay-portal="bottom-sheet"]');
+		if (!el) throw new Error("sheet portal node not rendered");
+		return el;
+	}
+	it("survives a mid-session re-render while open (the production repro)", () => {
+		// Repro shape: any store-driven re-render while the sheet is open
+		// (production trigger: the provider model-list fetch resolving).
+		const { rerender } = render(
+			<BottomSheet open={true} onClose={() => {}}>
+				<span>MIDLIFE1</span>
+			</BottomSheet>,
+		);
+		const sheetBefore = sheetEl(document);
+		expect(getTopmostOverlayPortal()).toBe(portalNode());
+		// Mid-life re-render while open — content changes, sheet stays open.
+		rerender(
+			<BottomSheet open={true} onClose={() => {}}>
+				<span>MIDLIFE2</span>
+			</BottomSheet>,
+		);
+		const sheetAfter = sheetEl(document);
+		// DOM identity preserved — no teardown/re-mount of the portal subtree.
+		expect(sheetAfter).toBe(sheetBefore);
+		expect(sheetAfter.isConnected).toBe(true);
+		// The sheet body must still live in the document (a self-targeted portal
+		// detaches the subtree from body under the old code).
+		expect(document.body.textContent).toContain("MIDLIFE2");
+		// The app host must not be inert-poisoned (leak symptom from the field).
+		const root = document.getElementById("root");
+		expect(root?.hasAttribute("data-base-ui-inert") ?? false).toBe(false);
+		expect(root?.getAttribute("aria-hidden")).not.toBe("true");
+	});
+
+	it("closes and reopens cleanly — no stuck session, anchor re-registers", () => {
+		// The field symptom ended with “opens once, then never again”. Pin the
+		// full open → close → reopen cycle: after a close the resolver must fall
+		// back (anchor unregistered), and the next open must re-register it and
+		// render live DOM again.
+		const { rerender } = render(
+			<BottomSheet open={true} onClose={() => {}}>
+				<span>CYCLE</span>
+			</BottomSheet>,
+		);
+		expect(getTopmostOverlayPortal()).toBe(portalNode());
+		rerender(
+			<BottomSheet open={false} onClose={() => {}}>
+				<span>CYCLE</span>
+			</BottomSheet>,
+		);
 		expect(getTopmostOverlayPortal()).toBeNull();
+		rerender(
+			<BottomSheet open={true} onClose={() => {}}>
+				<span>CYCLE</span>
+			</BottomSheet>,
+		);
+		const sheet = sheetEl(document);
+		expect(sheet.isConnected).toBe(true);
+		expect(document.body.textContent).toContain("CYCLE");
+		expect(getTopmostOverlayPortal()).toBe(portalNode());
+	});
+});
+
+describe("modal-helpers resolver hardening (SHEET_PORTAL_SELF_TARGETING)", () => {
+	// A teardown path that skips the ref cleanup (exactly the class of bug
+	// this hardening follows) can leave disconnected nodes in the overlay
+	// stack; the resolver must never return — or keep — a detached anchor.
+	it("skips and prunes disconnected top entries, falling to a connected one", () => {
+		const detached = document.createElement("div"); // never appended
+		const live = document.createElement("div");
+		document.body.appendChild(live);
+		const unDetached = registerOverlayPortal(detached);
+		const unLive = registerOverlayPortal(live);
+		try {
+			expect(getTopmostOverlayPortal()).toBe(live); // skips the detached top
+		} finally {
+			unDetached();
+			unLive();
+			live.remove();
+		}
+	});
+
+	it("returns null (and empties the stack) when every entry is disconnected", () => {
+		const detached = document.createElement("div");
+		registerOverlayPortal(detached); // leak: unregister never runs
+		expect(getTopmostOverlayPortal()).toBeNull();
+	});
+
+	it("getApplicationModalPortal ignores the overlay stack", () => {
+		// The rail (and any app-level overlay) must resolve a STABLE host that
+		// never chases the topmost sheet anchor — re-targeting mid-life is the
+		// self-targeting bug again, one level up.
+		const overlayNode = document.createElement("div");
+		document.body.appendChild(overlayNode);
+		const un = registerOverlayPortal(overlayNode);
+		const host = document.createElement("div");
+		host.id = "modal-portal";
+		document.body.appendChild(host);
+		try {
+			expect(getModalPortal()).toBe(overlayNode); // stack-consulting resolver
+			expect(getApplicationModalPortal()).toBe(host); // app-level: ignores stack
+		} finally {
+			un();
+			host.remove();
+			overlayNode.remove();
+		}
 	});
 });
 

--- a/apps/web/src/components/shared/BottomSheet.tsx
+++ b/apps/web/src/components/shared/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback, useLayoutEffect, useState, type ReactNode } from "react";
 import { Drawer } from "@base-ui/react/drawer";
 import { getModalPortal, registerOverlayPortal } from "./modal-helpers.js";
 
@@ -31,27 +31,67 @@ interface BottomSheetProps {
  * Base UI's `data-starting-style` / `data-ending-style` / `data-swiping` attrs
  * and the `--drawer-swipe-progress` / `--drawer-swipe-movement-y` CSS vars.
  *
- * The `container={getModalPortal() ?? document.body}` wiring on `Drawer.Portal`
- * portals the sheet into the nearest Radix Dialog's `#modal-portal` when the
- * sheet is rendered inside a modal (so it stays within that dialog's focus
- * trap); otherwise it portals to `document.body`. The explicit fallback is
- * load-bearing under happy-dom: the default container resolution does not fire
- * there (no layout), so the portal must be given a concrete node.
+ * The portal container is resolved ONCE per open transition and frozen for the
+ * sheet's whole open lifecycle — see the session notes in the component body
+ * (`reports/SHEET_PORTAL_SELF_TARGETING_REPORT.md`). The explicit
+ * `?? document.body` fallback is load-bearing under happy-dom: the default
+ * container resolution does not fire there (no layout), so the portal must
+ * always be given a concrete node.
  */
+
+/** One open lifecycle of the sheet: the portal container frozen at the open
+ *  transition (captured in the layout effect below, never during render). */
+interface PortalSession {
+  container: HTMLElement;
+}
+
 export function BottomSheet({ open, onClose, title, children }: BottomSheetProps) {
   // D2 (v1.2.1): register the sheet's own portal node so nested floating UI
   // (DropdownSelect popups) opened inside the sheet portals HERE — inside the
   // drawer's focus scope and stacking context — instead of document.body
   // (z-400, under the sheet's z-500/501).
   //
-  // State-free BY DESIGN (regression found by the MAE-53 sheet-close test):
-  // a useState+useEffect pair here caused an extra render while Base UI was
-  // running the drawer's exit transition, and the popup never unmounted —
-  // the sheet stopped closing. The registration now IS the anchor's mount:
-  // `{open && <div/>}` gates it on `open` (Base UI keeps the portal host
-  // mounted while closed, so an unconditionally-mounted anchor would leave a
-  // closed sheet registered as the topmost overlay), and the stable callback
-  // ref's return value is React 19's ref-cleanup (unregister on unmount).
+  // SHEET_PORTAL_SELF_TARGETING (v1.2.2): D2 made `getModalPortal()` consult
+  // the live overlay stack, and the portal container used to be re-evaluated
+  // on EVERY render. The first open render resolved `document.body`; after
+  // the anchor below registered at commit, any mid-session re-render (e.g. a
+  // store update like a model-list fetch resolving) resolved the container to
+  // the sheet's OWN anchor — React tore the portal subtree down mid-life,
+  // Base UI's inert restore never landed (`#root[data-base-ui-inert]` leaked
+  // forever), and `open` stayed true with no live DOM: "opens once, then
+  // never again", whole app dead to pointer input until reload. The fix:
+  // freeze the container in a session captured in the COMMIT phase only.
+  const [portalSession, setPortalSession] = useState<PortalSession | null>(null);
+
+  // Capture the container once per open transition. Render-phase capture
+  // (refs mutated during render) is unsafe under React 19 concurrent
+  // rendering — a render may be abandoned after mutating. The layout effect
+  // runs after commit, and the anchor is gated on the session existing, so at
+  // capture time the overlay stack cannot contain this sheet's anchor yet —
+  // self-targeting is structurally impossible.
+  //
+  // Deliberately NO state update on the closing edge: the session (and its
+  // container) is kept through the exit transition so the exiting drawer is
+  // never re-targeted, and a state update during exit is exactly what stalled
+  // the popup unmount in the MAE-53 regression (this component must stay
+  // state-free on the close path). A stale session from a previous cycle is
+  // simply replaced on the next open transition; the `isConnected` guard at
+  // render bounds a stale disconnected container to one frame in
+  // `document.body` before the fresh capture lands.
+  useLayoutEffect(() => {
+    if (!open) return;
+    setPortalSession({ container: getModalPortal() ?? document.body });
+  }, [open]);
+
+  const sessionActive = portalSession !== null;
+  const container =
+    portalSession && portalSession.container.isConnected
+      ? portalSession.container
+      : document.body;
+
+  // Stable callback ref; the returned function is React 19's ref-cleanup
+  // (unregister on unmount). `{open && ...}` gating keeps a closed sheet off
+  // the overlay stack.
   const portalAnchorRef = useCallback(
     (node: HTMLDivElement | null): (() => void) | undefined =>
       node === null ? undefined : registerOverlayPortal(node),
@@ -59,53 +99,59 @@ export function BottomSheet({ open, onClose, title, children }: BottomSheetProps
   );
   return (
     <Drawer.Root
-      open={open}
+      open={open && sessionActive}
       onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}
       modal
       swipeDirection="down"
     >
-      <Drawer.Portal container={getModalPortal() ?? document.body}>
-        {/* Scrim — `.inset-0` is the chrome selector BottomSheet.test.tsx
-         *  resolves; keep it verbatim across any restyling. */}
-        <Drawer.Backdrop className="bs-backdrop fixed inset-0 z-[500] bg-black backdrop-blur-sm" />
-        <Drawer.Viewport className="fixed inset-0 z-[501]">
-          {/* Sheet body — `.glass-blur` + safe-area + shadow are the chrome
+      {/* Staged until a session exists: the very first open render mounts NO
+       *  portal (container not yet captured); the layout effect above runs
+       *  synchronously before paint and the next render mounts the portal
+       *  into the frozen container — no body-then-swap, no first-frame flash. */}
+      {portalSession && (
+        <Drawer.Portal container={container}>
+          {/* Scrim — `.inset-0` is the chrome selector BottomSheet.test.tsx
+           *  resolves; keep it verbatim across any restyling. */}
+          <Drawer.Backdrop className="bs-backdrop fixed inset-0 z-[500] bg-black backdrop-blur-sm" />
+          <Drawer.Viewport className="fixed inset-0 z-[501]">
+            {/* Sheet body — `.glass-blur` + safe-area + shadow are the chrome
            *  selectors BottomSheet.test.tsx resolves; carried verbatim across
            *  the vaul → Base UI swap. */}
-          <Drawer.Popup className="bs-popup glass-blur fixed inset-x-0 bottom-0 flex flex-col rounded-t-2xl border-t border-border2 bg-glass-bg pb-[env(safe-area-inset-bottom,0px)] shadow-[0_-4px_24px_rgba(0,0,0,0.5)]">
-            {/* Drag handle — purely visual; Base UI owns the drag gesture on the
-             *  popup, so this is just the grabber bar (h-1 w-10 rounded-full
-             *  bg-border) with margin substituting for the old padding wrapper. */}
-            <div aria-hidden className="mx-auto mb-1 mt-2 block h-1 w-10 shrink-0 rounded-full bg-border" />
-            {/* Title — the dialog requires an accessible name. When the caller
-             *  passes a title it is rendered visibly AND serves as the name;
-             *  when omitted, a visually-hidden fallback satisfies the
-             *  requirement so the dialog validates without a stray label. */}
-            {title != null ? (
-              <Drawer.Title className="px-5 pb-2 pt-1 font-ui text-[calc(var(--ui-fs)-1px)] font-semibold text-t1">
-                {title}
-              </Drawer.Title>
-            ) : (
-              <Drawer.Title className="sr-only">Sheet</Drawer.Title>
-            )}
-            <Drawer.Content className="flex flex-col">{children}</Drawer.Content>
-          </Drawer.Popup>
-          {/* Portal anchor for nested floating UI (DropdownSelect popups).
+            <Drawer.Popup className="bs-popup glass-blur fixed inset-x-0 bottom-0 flex flex-col rounded-t-2xl border-t border-border2 bg-glass-bg pb-[env(safe-area-inset-bottom,0px)] shadow-[0_-4px_24px_rgba(0,0,0,0.5)]">
+              {/* Drag handle — purely visual; Base UI owns the drag gesture on the
+           *  popup, so this is just the grabber bar (h-1 w-10 rounded-full
+           *  bg-border) with margin substituting for the old padding wrapper. */}
+              <div aria-hidden className="mx-auto mb-1 mt-2 block h-1 w-10 shrink-0 rounded-full bg-border" />
+              {/* Title — the dialog requires an accessible name. When the caller
+           *  passes a title it is rendered visibly AND serves as the name;
+           *  when omitted, a visually-hidden fallback satisfies the
+           *  requirement so the dialog validates without a stray label. */}
+              {title != null ? (
+                <Drawer.Title className="px-5 pb-2 pt-1 font-ui text-[calc(var(--ui-fs)-1px)] font-semibold text-t1">
+                  {title}
+                </Drawer.Title>
+              ) : (
+                <Drawer.Title className="sr-only">Sheet</Drawer.Title>
+              )}
+              <Drawer.Content className="flex flex-col">{children}</Drawer.Content>
+            </Drawer.Popup>
+            {/* Portal anchor for nested floating UI (DropdownSelect popups).
            *  Mirrors Modal's #modal-portal (same 0×0 fixed node shape): it must
            *  sit inside the Viewport for focus trapping, but OUTSIDE the
            *  animated Popup — transforms break fixed positioning (Modal.tsx
            *  carries the same warning). Placed after the Popup so popup
            *  content paints above the sheet body within the z-501 context.
            *  Rendered only while `open` — see the registration note above. */}
-          {open && (
-            <div
-              ref={portalAnchorRef}
-              data-overlay-portal="bottom-sheet"
-              style={{ position: "fixed", top: 0, left: 0, width: 0, height: 0, overflow: "visible", pointerEvents: "auto" }}
-            />
-          )}
-        </Drawer.Viewport>
-      </Drawer.Portal>
+            {open && (
+              <div
+                ref={portalAnchorRef}
+                data-overlay-portal="bottom-sheet"
+                style={{ position: "fixed", top: 0, left: 0, width: 0, height: 0, overflow: "visible", pointerEvents: "auto" }}
+              />
+            )}
+          </Drawer.Viewport>
+        </Drawer.Portal>
+      )}
     </Drawer.Root>
   );
 }

--- a/apps/web/src/components/shared/DropdownSelect.tsx
+++ b/apps/web/src/components/shared/DropdownSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import * as Popover from "@radix-ui/react-popover";
 import { Command } from "cmdk";
 import { cn } from "../../lib/cn.js";
@@ -83,6 +83,19 @@ export function DropdownSelect({
   const [search, setSearch] = useState("");
   const commandRef = useRef<HTMLDivElement>(null);
 
+  // Popup portal container, frozen per popup-open session
+  // (SHEET_PORTAL_SELF_TARGETING): re-evaluating `getModalPortal()` on every
+  // render meant a stack-top change mid-popup (or a sheet re-render while this
+  // popup is open inside it) re-targeted the portal and tore the popup down.
+  // The rising edge of `open` always goes through handleOpenChange, so the
+  // container is captured in the same event/batch as the open flip — the
+  // first popup render already sees the frozen container, no staging gap.
+  // Kept through close (Radix exit presence — never re-target an exiting
+  // popup); replaced on the next open. `container: null` means "no overlay
+  // host — default body"; the session wrapper distinguishes it from
+  // "not resolved yet".
+  const [portalSession, setPortalSession] = useState<{ container: HTMLElement | null } | null>(null);
+
   const selected = (groups ? groups.flatMap((g) => g.options) : options).find((o) => o.id === value);
   const display = selected?.label || value || placeholder;
 
@@ -105,6 +118,7 @@ export function DropdownSelect({
   }
 
   function handleOpenChange(isOpen: boolean) {
+    if (isOpen) setPortalSession({ container: getModalPortal() });
     setOpen(isOpen);
     if (isOpen && searchable) setSearch("");
   }
@@ -122,8 +136,13 @@ export function DropdownSelect({
   // When inside an overlay (Modal, BottomSheet), portal into the topmost
   // overlay's anchor element so the content stays within that overlay's focus
   // scope AND paints above it (modal-helpers keeps a stack of overlay portal
-  // nodes; D2). When outside any overlay, portal to body.
-  const portalContainer = getModalPortal() ?? undefined;
+  // nodes; D2). When outside any overlay, portal to body. Resolved ONCE per
+  // popup-open session (see portalSession above); the isConnected guard bounds
+  // a stale disconnected container to one frame before the next capture.
+  const portalContainer =
+    portalSession?.container && portalSession.container.isConnected
+      ? portalSession.container
+      : undefined;
 
   function renderOption(o: DropdownOption) {
     return (

--- a/apps/web/src/components/shared/modal-helpers.ts
+++ b/apps/web/src/components/shared/modal-helpers.ts
@@ -24,13 +24,28 @@ export function registerOverlayPortal(node: HTMLElement): () => void {
   };
 }
 
-/** The innermost currently-open overlay's portal node, or null. */
+/** The innermost currently-open overlay's portal node, or null.
+ *  Hardened after SHEET_PORTAL_SELF_TARGETING: a teardown path that skips
+ *  the ref cleanup (exactly the bug this hardening follows) can leave
+ *  disconnected nodes in the stack; walk from the top, pruning them, so a
+ *  stale detached anchor can never become a portal target again. */
 export function getTopmostOverlayPortal(): HTMLElement | null {
-  return overlayPortalStack.length > 0
-    ? overlayPortalStack[overlayPortalStack.length - 1]
-    : null;
+  for (let i = overlayPortalStack.length - 1; i >= 0; i--) {
+    const node = overlayPortalStack[i];
+    if (node.isConnected) return node;
+    overlayPortalStack.splice(i, 1);
+  }
+  return null;
 }
 
 export function getModalPortal(): HTMLElement | null {
   return getTopmostOverlayPortal() ?? document.getElementById("modal-portal");
+}
+
+/** The application-level modal host — stable per call, independent of the
+ *  overlay stack. For overlays that must NEVER chase the topmost sheet
+ *  anchor (the rail sidebar): re-targeting their portal mid-life to a sheet
+ *  anchor tears them down exactly like SHEET_PORTAL_SELF_TARGETING. */
+export function getApplicationModalPortal(): HTMLElement | null {
+  return document.getElementById("modal-portal");
 }


### PR DESCRIPTION
## What

Post-D2 regression fix (`224b0985`, PR #37): the BottomSheet portal container was re-evaluated via `getModalPortal()` on every render. After the sheet's own anchor registered at commit, the next store-driven re-render (production trigger: the provider model-list fetch resolving) re-targeted `Drawer.Portal` into the **sheet's own anchor** — a node inside the subtree being re-targeted. React tore the portal down mid-life: the dialog DOM vanished while `open` stayed true (re-tap = no-op → «opens once, never again»), Base UI's inert restore never landed (`#root[data-base-ui-inert]` leaked forever), and the whole app went dead to pointer input until reload. Same class: rail nav rows dead-tapped.

Full diagnosis with evidence chain: `vibe_tavern_plan/reports/SHEET_PORTAL_SELF_TARGETING_REPORT.md`.

## Fix (per 3-model consult consensus)

- **BottomSheet**: portal container captured ONCE per open transition in a commit-phase session (`useLayoutEffect`); portal staged until the session exists; container kept through exit presence (no close-edge state updates — the MAE-53 stall must not return); anchor registration stays on React 19 ref-cleanup.
- **Rail**: resolves the app-level host (`getApplicationModalPortal`) — never chases the topmost sheet anchor.
- **DropdownSelect**: per-popup-open session container, captured in `handleOpenChange` in the same batch as the open flip (its `open` is local state — no staging gap needed).
- **modal-helpers**: `getTopmostOverlayPortal` skips+prunes disconnected nodes (a stale detached anchor can never become a portal target); new `getApplicationModalPortal`.

## Verification

- New regression test **red on dev tip, green on this branch** (mid-life re-render while open: DOM identity preserved, subtree stays connected, no inert/aria-hidden on #root); reopen-cycle and resolver-hardening pins added; D2 portal tests stay green.
- `bun run check` green (typecheck 7/7 workspaces, package suites, i18n parity) + web suite PASS (233 files) run directly.
- Live repro rig (mock OpenAI `/v1/models` on 9911 — the exact death trigger): sheet survives the fetch, Escape-close clears inert/aria-hidden fully, reopen works; rail row «Настройки провайдера» mounts the ProviderModal with clean teardown; dropdown popup opened inside the sheet portals into the sheet anchor (`data-overlay-portal=bottom-sheet`) and survives re-renders — the D2 feature is preserved, not just un-crashed.